### PR TITLE
docs: update toc link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can track our progress towards Sprout v1.0 by following the documentation pa
   - [Working with Templates](#working-with-templates)
 - [Usage: Quick Example (code only)](#usage-quick-example)
 - [Performance Benchmarks](#performance-benchmarks)
-  - [Sprig v3.2.3 vs Sprout v0.2](#sprig-v323-vs-sprout-v02)
+  - [Sprig v3.2.3 vs Sprout v0.5](#sprig-v323-vs-sprout-v05)
 - [Development Philosophy (Currently in reflexion to create our)](#development-philosophy-currently-in-reflexion-to-create-our)
 
 


### PR DESCRIPTION
## Description
`Sprig v3.2.3 vs Sprout v0.5` entry in the TOC doesn't match the actual text

## Changes
Update the TOC entry

## Fixes <!-- #issueNumber -->

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.

## Additional Information
<!-- Any additional information regarding this pull request. -->
