### PR TITLE
fix: make derivePassword return the correct value when used with sprigin

### DIFF
--- a/docs/registries/crypto.md
+++ b/docs/registries/crypto.md
@@ -71,7 +71,7 @@ The function derives a password based on the provided counter, password type, pa
 {% tabs %}
 {% tab title="Template Example" %}
 ```go
-{{ derivePassword 1 "long" "password" "user" "example.com" }} // Output: "$2a$12$C1qL8XVjIuGKzQXwC6g6tO"
+{{ derivePassword 1 "long" "password" "user" "example.com" }} // Output: "ZedaFaxcZaso9*"
 ```
 {% endtab %}
 {% endtabs %}

--- a/registry/crypto/functions.go
+++ b/registry/crypto/functions.go
@@ -74,7 +74,7 @@ func (ch *CryptoRegistry) Htpasswd(username string, password string) (string, er
 // For an example of this function in a Go template, refer to [Sprout Documentation: derivePassword].
 //
 // [Sprout Documentation: derivePassword]: https://docs.atom.codes/sprout/registries/crypto#derivepassword
-func (ch *CryptoRegistry) DerivePassword(counter uint32, passwordType, password, user, site string) (string, error) {
+func (ch *CryptoRegistry) DerivePassword(counter int, passwordType, password, user, site string) (string, error) {
 	templates := passwordTypeTemplates[passwordType]
 	if templates == nil {
 		return "", fmt.Errorf("cannot find password template %s", passwordType)
@@ -94,7 +94,7 @@ func (ch *CryptoRegistry) DerivePassword(counter uint32, passwordType, password,
 	buffer.Truncate(len(masterPasswordSeed))
 	_ = binary.Write(&buffer, binary.BigEndian, uint32(len(site)))
 	buffer.WriteString(site)
-	_ = binary.Write(&buffer, binary.BigEndian, counter)
+	_ = binary.Write(&buffer, binary.BigEndian, uint32(counter))
 
 	hmacv := hmac.New(sha256.New, key)
 	hmacv.Write(buffer.Bytes())

--- a/registry/crypto/functions_test.go
+++ b/registry/crypto/functions_test.go
@@ -1,0 +1,16 @@
+package crypto_test
+
+import (
+	"testing"
+
+	"github.com/go-sprout/sprout/pesticide"
+	"github.com/go-sprout/sprout/registry/crypto"
+)
+
+func TestDerivePassword(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestSimple", Input: `{{ derivePassword 1 "long" "password" "user" "example.com" }}`, ExpectedOutput: "ZedaFaxcZaso9*"},
+	}
+
+	pesticide.RunTestCases(t, crypto.NewRegistry(), tc)
+}

--- a/sprigin/sprigin_test.go
+++ b/sprigin/sprigin_test.go
@@ -1,0 +1,42 @@
+package sprigin_test
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-sprout/sprout/sprigin"
+)
+
+func TestSprigin(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		funcMap  template.FuncMap
+		text     string
+		data     any
+		expected string
+	}{
+		{
+			name:     "bcrypt",
+			funcMap:  sprigin.HermeticTxtFuncMap(),
+			text:     `{{ bcrypt "abc" | trunc 7 }}`, // Only the first seven bytes of bcrypt output is consistent.
+			expected: "$2a$10$",
+		},
+		{
+			name:     "derivePassword",
+			funcMap:  sprigin.HermeticTxtFuncMap(),
+			text:     `{{ derivePassword 1 "long" "password" "user" "example.com" }}`,
+			expected: "ZedaFaxcZaso9*",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl, err := template.New(tc.name).Funcs(tc.funcMap).Parse(tc.text)
+			assert.NoError(t, err)
+			var builder strings.Builder
+			assert.NoError(t, tmpl.Execute(&builder, tc.data))
+			assert.Equal(t, tc.expected, builder.String())
+		})
+	}
+}


### PR DESCRIPTION
## Description

As reported by @marmitar in https://github.com/twpayne/chezmoi/issues/2668#issuecomment-3708923834, `derivePassword`, when used with `sprigin`, always returns an empty string.

This one is really weird, which is why I've made a PR rather than opening an issue. See the tests in this PR. Before the fix:

* `derivePassword`, when called directly in the crypto registry tests, returns the correct value.
* `derivePassword`, when called via `sprigin.HermeticTxtFuncMap()`, always returns the empty string.

I simply don't understand what is happening here. In the second test, using `sprigin.HermeticTxtFuncMap()`, it the `derivePassword` function is *never called*. You can reproduce this by reverting the last commit in this PR and putting a `panic` as the first line of `CryptoRegistry.DerivePassword` function or setting a breakpoint in your debugger at `CryptoRegistry.DerivePassword` and debugging the `sprigin` test.

I suspected that the `counter uint32` parameter to the function might be causing a problem, but [Sprig uses a `uint32`](https://github.com/Masterminds/sprig/blob/989da45d7c082c6ec85cf95f59e23b461cdafe03/crypto.go#L137) and `derivePassword` works there.

But! Changing the parameter from `counter uint32` to `counter int` does indeed fix the problem! This makes no sense!

I also tried stepping into the template execution, but there's a lot of scary `reflect` magic and I got lost.

## Changes

This fixes the `derivePassword` function for `sprigin` users and fixes the example output in the documentation.

## Fixes (same issue as this PR)

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.

## Additional Information

I am confused.