### PR TITLE
chore: test on supported go versions only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## Description

CI tests claim to run on versions of Go since 1.21.x, but [`go.mod` specifies a minimum Go versions of 1.24](https://github.com/go-sprout/sprout/blob/66938298414c45bbcad9011d4f15a17500bbf299/go.mod#L3).

Testing with these old versions of Go is meaningless as, [since Go 1.21](https://go.dev/doc/go1.21#tools), older versions of Go will download and run a more recent version of Go instead.

## Changes

Saves CI cycles.

## Fixes (this PR number)

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.

## Additional Information

n/a