### PR TITLE
fix(sprigin): don't split keys on dots for the compatibility dig (#159)

### DIFF
--- a/docs/migration-from-sprig.md
+++ b/docs/migration-from-sprig.md
@@ -238,8 +238,12 @@ if err != nil {
 
 #### Dig
 
-* **Sprig**: The `dig` function requires a default value as the second-to-last argument: `{{ dig "a" "b" "default" $dict }}`. It returns the last map in the access chain instead of the final value.
-* **Sprout**: The `dig` function does not include a default value: `{{ $dict | dig "a" "b" }}`. Use the `default` filter instead: `{{ $dict | dig "a" "b" | default "default" }}`. It returns the final value in the chain, regardless of its type.
+* **Sprig**:
+  * The `dig` function requires a default value as the second-to-last argument: `{{ dig "a" "b" "default" $dict }}`. It returns the last map in the access chain instead of the final value.
+  * Dots in keys are treated literally: `{{ dict "a" (dict "b" 5) | dig "a.b" "missing" }}` results in `missing`.
+* **Sprout**:
+  * The `dig` function does not include a default value: `{{ $dict | dig "a" "b" }}`. Use the `default` filter instead: `{{ $dict | dig "a" "b" | default "default" }}`. It returns the final value in the chain, regardless of its type.
+  * Keys are split on dots when accessing nested values: `{{ dict "a" (dict "b" 5) | dig "a.b" | default "missing" }}` results in `5`.
 
 {% hint style="info" %}
 If you use `sprigin.FuncMap()`, the `dig` function retains Sprig's signature with the default value parameter for backward compatibility.

--- a/registry/maps/functions.go
+++ b/registry/maps/functions.go
@@ -397,6 +397,7 @@ func (mr *MapsRegistry) Dig(args ...any) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse keys: %w", err)
 	}
+	keys = mr.splitKeys(keys)
 
 	return mr.digIntoDict(dict, keys)
 }

--- a/registry/maps/helpers.go
+++ b/registry/maps/helpers.go
@@ -55,28 +55,56 @@ func (mr *MapsRegistry) digIntoDict(dict map[string]any, keys []string) (any, er
 //	keys, err := mr.parseKeys([]any{"key1", 2})
 //	fmt.Println(err) // Output: all keys must be strings, got int at position 1
 func (mr *MapsRegistry) parseKeys(keySet []any) ([]string, error) {
-	// Calculate the total number of keys needed
-	totalKeys := 0
+	keys := make([]string, 0, len(keySet))
+
+	// Convert each key to string
 	for i, element := range keySet {
 		key, ok := element.(string)
 		if !ok {
 			return nil, fmt.Errorf("all keys must be strings, got %T at position %d", element, i)
 		}
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+// splitKeys breaks up nested keys into simple key elements, splitting on dots.
+//
+// Parameters:
+//
+//	keySet []string - a slice with simple and nested keys.
+//
+// Returns:
+//
+//	[]string - a slice containing only simple keys, possibly split from nested ones.
+//
+// Example:
+//
+//	keys := mr.splitKeys([]string{"a", "nested.key"})
+//	fmt.Printf("%q\n", keys) // Output: ["a" "nested" "key"]
+//
+//	keys := mr.splitKeys([]string{"only", "simple", "keys"})
+//	fmt.Printf("%q\n", keys) // Output: ["only" "simple" "keys"]
+func (mr *MapsRegistry) splitKeys(keySet []string) []string {
+	// Calculate the total number of keys needed
+	totalKeys := 0
+	for _, key := range keySet {
 		totalKeys += 1 + strings.Count(key, ".")
+	}
+
+	// Only simple keys found, no need to split anything
+	if totalKeys == len(keySet) {
+		return keySet
 	}
 
 	// Preallocate the slice with the exact number of required elements
 	keys := make([]string, 0, totalKeys)
 
 	// Now, fill the slice
-	for _, element := range keySet {
-		key := element.(string)
-		if strings.Contains(key, ".") {
-			keys = append(keys, strings.Split(key, ".")...)
-		} else {
-			keys = append(keys, key)
-		}
+	for _, key := range keySet {
+		keys = append(keys, strings.Split(key, ".")...)
 	}
 
-	return keys, nil
+	return keys
 }

--- a/registry/maps/sprig_deprecated_functions_signature_test.go
+++ b/registry/maps/sprig_deprecated_functions_signature_test.go
@@ -94,6 +94,7 @@ func TestDeprecatedDig(t *testing.T) {
 		{Name: "TestDeeplyNestedNotFound", Input: `{{dig "a" "b" "x" "default" .}}`, ExpectedOutput: "default", Data: map[string]any{"a": map[string]any{"b": map[string]any{"c": "deep"}}}},
 		{Name: "TestEmptyDict", Input: `{{dig "a" "default" .}}`, ExpectedOutput: "default", Data: map[string]any{}},
 		{Name: "TestIntegerValue", Input: `{{dig "count" "0" .}}`, ExpectedOutput: "42", Data: map[string]any{"count": 42}},
+		{Name: "TestKeysWithDots", Input: `{{dig "has.dot" "default" .}}`, ExpectedOutput: "value", Data: map[string]any{"has.dot": "value"}},
 		{Name: "TestNotEnoughArgs", Input: `{{dig "a" .}}`, ExpectedErr: "dig requires at least three arguments", Data: map[string]any{"a": 1}},
 		{Name: "TestInvalidLastArg", Input: `{{dig "a" "default" "notamap"}}`, ExpectedErr: "last argument must be a map[string]any"},
 		{Name: "TestInvalidKeyType", Input: `{{dig .num "default" .dict}}`, ExpectedErr: "all keys must be strings", Data: map[string]any{"num": 123, "dict": map[string]any{"a": 1}}},


### PR DESCRIPTION
## Description
<!-- Please provide a clear and concise description of what the pull request achieves. Mention the issue it addresses (if applicable). -->

This PR reverts the nested single key (`dig "nested.foo"`) functionality from `dig`'s compatibility layer and adds documentation about this difference with sprout's `dig`.

## Changes
<!--
- Detail the changes you have introduced.
- Highlight any new functionality.
-->

- Simplify `parseKeys` to do only what it documentation says.
- Add a new `splitKeys` function that does the extra functionality (only used in non-compat `dig`).
- Add a simple test case for the overall fix.
- Explicitly mention this breaking change on the migration docs.

## Fixes #159

## Checklist
- [X] I have read the **CONTRIBUTING.md** document.
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation accordingly.
- [X] This change requires a change to the documentation on the website.

## Additional Information
<!-- Any additional information regarding this pull request. -->

Note: Just one way to solve this. Feel free to update the code or close in favor of an alternative fix.
