### PR TITLE
feat: add new functions for unix conversions

### DIFF
--- a/docs/registries/time.md
+++ b/docs/registries/time.md
@@ -117,6 +117,88 @@ The function returns the Unix epoch timestamp for a given date.
 {% endtab %}
 {% endtabs %}
 
+{% hint style="info" %}
+`toUnix` is an alias of `unixEpoch`, both can be used interchangeably.
+{% endhint %}
+
+### <mark style="color:purple;">toUnixMilli</mark>
+
+The function returns the Unix epoch timestamp in milliseconds for a given date.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">ToUnixMilli(date time.Time) string
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ now | toUnixMilli }} // Output(will be different): 1683306245123
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">toUnixMicro</mark>
+
+The function returns the Unix epoch timestamp in microseconds for a given date.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">ToUnixMicro(date time.Time) string
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ now | toUnixMicro }} // Output(will be different): 1683306245123456
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">fromUnix</mark>
+
+The function converts a Unix epoch timestamp in seconds into a date, in the local timezone.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">FromUnix(timestamp any) (time.Time, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ 1683306245 | fromUnix | date "Jan 2, 2006" }} // Output: "May 5, 2023"
+{{ "invalid" | fromUnix }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">fromUnixMilli</mark>
+
+The function converts a Unix epoch timestamp in milliseconds into a date, in the local timezone.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">FromUnixMilli(timestamp any) (time.Time, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ 1683306245123 | fromUnixMilli | date "Jan 2, 2006" }} // Output: "May 5, 2023"
+{{ "invalid" | fromUnixMilli }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">fromUnixMicro</mark>
+
+The function converts a Unix epoch timestamp in microseconds into a date, in the local timezone.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">FromUnixMicro(timestamp any) (time.Time, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ 1683306245123456 | fromUnixMicro | date "Jan 2, 2006" }} // Output: "May 5, 2023"
+{{ "invalid" | fromUnixMicro }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
 ### <mark style="color:purple;">dateModify</mark>
 
 The function adjusts a given date by a specified duration, returning the modified date. If the duration format is incorrect, it returns the original date without any changes, in case of must version, an error is returned.

--- a/registry/time/functions.go
+++ b/registry/time/functions.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/spf13/cast"
 )
 
 // Date formats a given date or current time into a specified format string.
@@ -151,6 +153,109 @@ func (tr *TimeRegistry) Now() time.Time {
 // [Sprout Documentation: unixEpoch]: https://docs.atom.codes/sprout/registries/time#unixepoch
 func (tr *TimeRegistry) UnixEpoch(date time.Time) string {
 	return strconv.FormatInt(date.Unix(), 10)
+}
+
+// ToUnixMilli returns the Unix epoch timestamp in milliseconds of a given date.
+//
+// Parameters:
+//
+//	date time.Time - the date to convert to a Unix timestamp.
+//
+// Returns:
+//
+//	string - the Unix timestamp in milliseconds as a string.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: toUnixMilli].
+//
+// [Sprout Documentation: toUnixMilli]: https://docs.atom.codes/sprout/registries/time#tounixmilli
+func (tr *TimeRegistry) ToUnixMilli(date time.Time) string {
+	return strconv.FormatInt(date.UnixMilli(), 10)
+}
+
+// ToUnixMicro returns the Unix epoch timestamp in microseconds of a given date.
+//
+// Parameters:
+//
+//	date time.Time - the date to convert to a Unix timestamp.
+//
+// Returns:
+//
+//	string - the Unix timestamp in microseconds as a string.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: toUnixMicro].
+//
+// [Sprout Documentation: toUnixMicro]: https://docs.atom.codes/sprout/registries/time#tounixmicro
+func (tr *TimeRegistry) ToUnixMicro(date time.Time) string {
+	return strconv.FormatInt(date.UnixMicro(), 10)
+}
+
+// FromUnix converts a Unix epoch timestamp in seconds into a date, in the
+// local timezone.
+//
+// Parameters:
+//
+//	timestamp any - the Unix timestamp in seconds to convert to a date.
+//
+// Returns:
+//
+//	time.Time - the date corresponding to the given timestamp.
+//	error - when the timestamp is not a valid number.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: fromUnix].
+//
+// [Sprout Documentation: fromUnix]: https://docs.atom.codes/sprout/registries/time#fromunix
+func (tr *TimeRegistry) FromUnix(timestamp any) (time.Time, error) {
+	sec, err := cast.ToInt64E(timestamp)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(sec, 0), nil
+}
+
+// FromUnixMilli converts a Unix epoch timestamp in milliseconds into a date,
+// in the local timezone.
+//
+// Parameters:
+//
+//	timestamp any - the Unix timestamp in milliseconds to convert to a date.
+//
+// Returns:
+//
+//	time.Time - the date corresponding to the given timestamp.
+//	error - when the timestamp is not a valid number.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: fromUnixMilli].
+//
+// [Sprout Documentation: fromUnixMilli]: https://docs.atom.codes/sprout/registries/time#fromunixmilli
+func (tr *TimeRegistry) FromUnixMilli(timestamp any) (time.Time, error) {
+	msec, err := cast.ToInt64E(timestamp)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.UnixMilli(msec), nil
+}
+
+// FromUnixMicro converts a Unix epoch timestamp in microseconds into a date,
+// in the local timezone.
+//
+// Parameters:
+//
+//	timestamp any - the Unix timestamp in microseconds to convert to a date.
+//
+// Returns:
+//
+//	time.Time - the date corresponding to the given timestamp.
+//	error - when the timestamp is not a valid number.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: fromUnixMicro].
+//
+// [Sprout Documentation: fromUnixMicro]: https://docs.atom.codes/sprout/registries/time#fromunixmicro
+func (tr *TimeRegistry) FromUnixMicro(timestamp any) (time.Time, error) {
+	usec, err := cast.ToInt64E(timestamp)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.UnixMicro(usec), nil
 }
 
 // DateModify adjusts a given date by a specified duration. If the duration

--- a/registry/time/functions_test.go
+++ b/registry/time/functions_test.go
@@ -155,6 +155,68 @@ func TestUnixEpoch(t *testing.T) {
 
 	tc := []pesticide.TestCase{
 		{Name: "TestUnixEpoch", Input: `{{ .V | unixEpoch }}`, ExpectedOutput: "1715094245", Data: map[string]any{"V": timeTest}},
+		{Name: "TestToUnixAlias", Input: `{{ .V | toUnix }}`, ExpectedOutput: "1715094245", Data: map[string]any{"V": timeTest}},
+	}
+
+	pesticide.RunTestCases(t, rtime.NewRegistry(), tc)
+}
+
+func TestToUnixMilli(t *testing.T) {
+	timeTest := time.Date(2024, 5, 7, 15, 4, 5, 123456789, time.UTC)
+
+	tc := []pesticide.TestCase{
+		{Name: "TestTimeObject", Input: `{{ .V | toUnixMilli }}`, ExpectedOutput: "1715094245123", Data: map[string]any{"V": timeTest}},
+	}
+
+	pesticide.RunTestCases(t, rtime.NewRegistry(), tc)
+}
+
+func TestToUnixMicro(t *testing.T) {
+	timeTest := time.Date(2024, 5, 7, 15, 4, 5, 123456789, time.UTC)
+
+	tc := []pesticide.TestCase{
+		{Name: "TestTimeObject", Input: `{{ .V | toUnixMicro }}`, ExpectedOutput: "1715094245123456", Data: map[string]any{"V": timeTest}},
+	}
+
+	pesticide.RunTestCases(t, rtime.NewRegistry(), tc)
+}
+
+func TestFromUnix(t *testing.T) {
+	// temporarily force time.Local to UTC to keep the output deterministic
+	pesticide.ForceTimeLocal(t, time.UTC)
+
+	tc := []pesticide.TestCase{
+		{Name: "TestInt", Input: `{{ .V | fromUnix | date "02 Jan 06 15:04:05 -0700" }}`, ExpectedOutput: "07 May 24 15:04:05 +0000", Data: map[string]any{"V": int(1715094245)}},
+		{Name: "TestInt64", Input: `{{ .V | fromUnix | date "02 Jan 06 15:04:05 -0700" }}`, ExpectedOutput: "07 May 24 15:04:05 +0000", Data: map[string]any{"V": int64(1715094245)}},
+		{Name: "TestString", Input: `{{ .V | fromUnix | date "02 Jan 06 15:04:05 -0700" }}`, ExpectedOutput: "07 May 24 15:04:05 +0000", Data: map[string]any{"V": "1715094245"}},
+		{Name: "TestZeroValue", Input: `{{ .V | fromUnix | date "02 Jan 06 15:04:05 -0700" }}`, ExpectedOutput: "01 Jan 70 00:00:00 +0000", Data: map[string]any{"V": 0}},
+		{Name: "TestWithInvalidInput", Input: `{{ .V | fromUnix }}`, ExpectedErr: "unable to cast", Data: map[string]any{"V": "invalid"}},
+	}
+
+	pesticide.RunTestCases(t, rtime.NewRegistry(), tc)
+}
+
+func TestFromUnixMilli(t *testing.T) {
+	// temporarily force time.Local to UTC to keep the output deterministic
+	pesticide.ForceTimeLocal(t, time.UTC)
+
+	tc := []pesticide.TestCase{
+		{Name: "TestInt64", Input: `{{ .V | fromUnixMilli | date "02 Jan 06 15:04:05.000 -0700" }}`, ExpectedOutput: "07 May 24 15:04:05.123 +0000", Data: map[string]any{"V": int64(1715094245123)}},
+		{Name: "TestString", Input: `{{ .V | fromUnixMilli | date "02 Jan 06 15:04:05.000 -0700" }}`, ExpectedOutput: "07 May 24 15:04:05.123 +0000", Data: map[string]any{"V": "1715094245123"}},
+		{Name: "TestWithInvalidInput", Input: `{{ .V | fromUnixMilli }}`, ExpectedErr: "unable to cast", Data: map[string]any{"V": "invalid"}},
+	}
+
+	pesticide.RunTestCases(t, rtime.NewRegistry(), tc)
+}
+
+func TestFromUnixMicro(t *testing.T) {
+	// temporarily force time.Local to UTC to keep the output deterministic
+	pesticide.ForceTimeLocal(t, time.UTC)
+
+	tc := []pesticide.TestCase{
+		{Name: "TestInt64", Input: `{{ .V | fromUnixMicro | date "02 Jan 06 15:04:05.000000 -0700" }}`, ExpectedOutput: "07 May 24 15:04:05.123456 +0000", Data: map[string]any{"V": int64(1715094245123456)}},
+		{Name: "TestString", Input: `{{ .V | fromUnixMicro | date "02 Jan 06 15:04:05.000000 -0700" }}`, ExpectedOutput: "07 May 24 15:04:05.123456 +0000", Data: map[string]any{"V": "1715094245123456"}},
+		{Name: "TestWithInvalidInput", Input: `{{ .V | fromUnixMicro }}`, ExpectedErr: "unable to cast", Data: map[string]any{"V": "invalid"}},
 	}
 
 	pesticide.RunTestCases(t, rtime.NewRegistry(), tc)

--- a/registry/time/time.go
+++ b/registry/time/time.go
@@ -30,6 +30,11 @@ func (tr *TimeRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error {
 	sprout.AddFunction(funcsMap, "dateAgo", tr.DateAgo)
 	sprout.AddFunction(funcsMap, "now", tr.Now)
 	sprout.AddFunction(funcsMap, "unixEpoch", tr.UnixEpoch)
+	sprout.AddFunction(funcsMap, "toUnixMilli", tr.ToUnixMilli)
+	sprout.AddFunction(funcsMap, "toUnixMicro", tr.ToUnixMicro)
+	sprout.AddFunction(funcsMap, "fromUnix", tr.FromUnix)
+	sprout.AddFunction(funcsMap, "fromUnixMilli", tr.FromUnixMilli)
+	sprout.AddFunction(funcsMap, "fromUnixMicro", tr.FromUnixMicro)
 	sprout.AddFunction(funcsMap, "dateModify", tr.DateModify)
 	sprout.AddFunction(funcsMap, "durationRound", tr.DurationRound)
 	sprout.AddFunction(funcsMap, "htmlDate", tr.HtmlDate)
@@ -39,6 +44,7 @@ func (tr *TimeRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error {
 
 func (tr *TimeRegistry) RegisterAliases(aliasesMap sprout.FunctionAliasMap) error {
 	sprout.AddAlias(aliasesMap, "dateModify", "mustDateModify")
+	sprout.AddAlias(aliasesMap, "unixEpoch", "toUnix")
 	return nil
 }
 

--- a/sprigin/sprig_backward_compatibility_test.go
+++ b/sprigin/sprig_backward_compatibility_test.go
@@ -54,7 +54,7 @@ func TestSprigHandler(t *testing.T) {
 	handler.Build()
 
 	assert.GreaterOrEqual(t, len(handler.RawFunctions()), sprigFunctionCount)
-	assert.Len(t, handler.RawAliases(), 38) // Hardcoded for backward compatibility
+	assert.Len(t, handler.RawAliases(), 39) // Hardcoded for backward compatibility
 
 	assert.Len(t, handler.registries, 18) // Hardcoded for backward compatibility
 


### PR DESCRIPTION
## Description

The time registry has `unixEpoch` to convert a `time.Time` into seconds since epoch, but no way to do the reverse. This PR adds the missing conversions in both directions, in seconds, milliseconds and microseconds.

## Changes

- **New alias** `toUnix` on `unixEpoch`, so both naming conventions are available and the `to*`/`from*` pair reads symmetrically. No function is duplicated at runtime.
- **New functions** in the `time` registry: `toUnixMilli`, `toUnixMicro`, `fromUnix`, `fromUnixMilli`, `fromUnixMicro`

## Fixes #130

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.