### PR TITLE
chore: turn regex functions main parameter to last position like othe…

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
 * [Network](registries/network.md)
 * [Random](registries/random.md)
 * [Reflect](registries/reflect.md)
+* [Regex](registries/regex.md)
 * [Regexp](registries/regexp.md)
 * [SemVer](registries/semver.md)
 * [Slices](registries/slices.md)

--- a/docs/registries/list-of-all-registries.md
+++ b/docs/registries/list-of-all-registries.md
@@ -20,7 +20,8 @@ Every function is categorized into a registry and may include a [**'must'** vers
 * [**numeric**](numeric.md): Utilities for numerical operations and calculations.
 * [**random**](random.md): Functions to generate random numbers, strings, and other data.
 * [**reflect**](reflect.md): Tools to inspect and manipulate data types using reflection.
-* [**regexp**](regexp.md): Regular expression functions for pattern matching and string manipulation.
+* [**regex**](regex.md): Regular expression functions for pattern matching and string manipulation, pipeline friendly.
+* [**regexp**](regexp.md): Regular expression functions using the historical sprig signatures. _Deprecated, use_ [_**regex**_](regex.md) _instead._
 * [**semver**](semver.md): Functions to handle semantic versioning and comparison.
 * [**slices**](slices.md): Utilities for slice operations, including filtering, sorting, and transforming.
 * [**std**](std.md): Standard functions for common operations.

--- a/docs/registries/regex.md
+++ b/docs/registries/regex.md
@@ -1,0 +1,217 @@
+---
+description: >-
+  The Regex registry includes functions for pattern matching and string
+  manipulation using regular expressions, where the main parameter is always the
+  last one to be usable in a template pipeline.
+---
+
+# Regex
+
+{% hint style="info" %}
+You can easily import all the functions from the <mark style="color:yellow;">`regex`</mark> registry by including the following import statement in your code
+
+```go
+import "github.com/go-sprout/sprout/registry/regex"
+```
+{% endhint %}
+
+{% hint style="warning" %}
+The `regex` registry replaces the deprecated [`regexp`](regexp.md) registry, which keeps the historical sprig signatures. Both registries expose the same function names, so they are **mutually exclusive**: register one or the other, never both.
+
+Only four functions change their signature, the string to work on moves to the last position:
+
+| `regexp` (deprecated)                                   | `regex`                                                 |
+| ------------------------------------------------------- | ------------------------------------------------------- |
+| `regexFindAll <regex> <value> <n>`                      | `regexFindAll <regex> <n> <value>`                      |
+| `regexSplit <regex> <value> <n>`                        | `regexSplit <regex> <n> <value>`                        |
+| `regexReplaceAll <regex> <value> <replacedBy>`          | `regexReplaceAll <regex> <replacedBy> <value>`          |
+| `regexReplaceAllLiteral <regex> <value> <replacedBy>`   | `regexReplaceAllLiteral <regex> <replacedBy> <value>`   |
+
+All the other functions keep the exact same signature, only the import changes. The `must` prefixed versions are not carried over, use the standard functions instead.
+{% endhint %}
+
+### <mark style="color:purple;">regexFind</mark>
+
+The function returns the first match found in the string that corresponds to the specified regular expression pattern.
+
+<table data-header-hidden><thead><tr><th width="174">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexFind(regex string, value string) (string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "hello world" | regexFind "hello" }} // Output: "hello"
+{{ "hello world" | regexFind "\\invalid$^///" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexFindAll</mark>
+
+The function returns all matches of the regex pattern in the string, up to a specified maximum number of matches (`n`).
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexFindAll(regex string, n int, value string) ([]string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "aba acada afa" | regexFindAll "a." 3 }} // Output: [ab a  ac]
+{{ "aba acada afa" | regexFindAll "\\invalid$^///" 3 }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexMatch</mark>
+
+The function checks if the entire string matches the given regular expression pattern.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexMatch(regex string, value string) (bool, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "Hello" | regexMatch "^[a-zA-Z]+$" }} // Output: true
+{{ "Hello" | regexMatch "\\invalid$^///" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexSplit</mark>
+
+The function splits the string into substrings based on matches of the regex pattern, performing the split up to `n` times.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexSplit(regex string, n int, value string) ([]string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "hello world from Go" | regexSplit "\\s+" 2 }} // Output: [hello world from Go]
+{{ "hello world from Go" | regexSplit "\\invalid$^///" 2 }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+The output above is a slice of two elements, `hello` and `world from Go`, rendered by the template engine.
+{% endhint %}
+
+### <mark style="color:purple;">regexReplaceAll</mark>
+
+The function replaces all occurrences of the regex pattern in the string with the specified replacement string.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexReplaceAll(regex string, replacedBy string, value string) (string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "R2D2 C3PO" | regexReplaceAll "\\d" "X" }} // Output: "RXDX CXPO"
+{{ "R2D2 C3PO" | regexReplaceAll "\\invalid$^///" "X" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexReplaceAllLiteral</mark>
+
+The function replaces all occurrences of the regex pattern in the string with the specified literal replacement string, without interpreting any special characters in the replacement.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexReplaceAllLiteral(regex string, replacedBy string, value string) (string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "hello world" | regexReplaceAllLiteral "world" "$1" }} // Output: "hello $1"
+{{ "hello world" | regexReplaceAllLiteral "none" "all" }} // Output: "hello world"
+{{ "hello world" | regexReplaceAllLiteral "\\invalid$^///" "all" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexQuoteMeta</mark>
+
+The function returns a version of the provided string that can be used as a literal pattern in a regular expression, escaping any special characters.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexQuoteMeta(value string) string
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ regexQuoteMeta ".+*?^$()[]{}|" }}
+// Output: \\.\\+\\*\\?\\^\\$\\(\\)\\[\\]\\{\\}\\|
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexFindGroups</mark>
+
+The function finds the first match of a regex pattern in a string and returns the matched groups, with error handling.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexFindGroups(regex string, value string) ([]string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "aaabbb" | regexFindGroups "(a+)(b+)" }} // Output: [aaabbb aaa bbb]
+{{ "aaabbb" | regexFindGroups "\\invalid$^///" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexFindAllGroups</mark>
+
+The function finds all matches of a regex pattern in a string up to a specified limit and returns the matched groups, with error handling.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexFindAllGroups(regex string, n int, value string) ([][]string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "aaabbb aab aaabbb" | regexFindAllGroups "(a+)(b+)" -1 }} // Output: [[aaabbb aaa bbb] [aab aa b] [aaabbb aaa bbb]]
+{{ "aaabbb aab aaabbb" | regexFindAllGroups "(a+)(b+)" 1 }} // Output: [[aaabbb aaa bbb]]
+{{ "aaabbb" | regexFindAllGroups "\\invalid$^///" -1 }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexFindNamed</mark>
+
+The function finds the first match of a regex pattern with named capturing groups in a string and returns a map of group names to matched strings, with error handling.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexFindNamed(regex string, value string) (map[string]string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "aaabbb" | regexFindNamed "(?P<first>a+)(?P<second>b+)" }} // Output: map[first:aaa second:bbb]
+{{ "aaabbb" | regexFindNamed "(?P<first>a+)(b+)" }} // Output: map[first:aaa]
+{{ "bbb" | regexFindNamed "(?P<first>a+)" }} // Output: map[]
+{{ "aaabbb" | regexFindNamed "\\invalid$^///" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">regexFindAllNamed</mark>
+
+The function finds all matches of a regex pattern with named capturing groups in a string up to a specified limit and returns a slice of maps of group names to matched strings, with error handling.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">RegexFindAllNamed(regex string, n int, value string) ([]map[string]string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "var1=value1&var2=value2" | regexFindAllNamed "(?P<param>\\w+)=(?P<value>\\w+)" -1 }} // Output: [map[param:var1 value:value1] map[param:var2 value:value2]]
+{{ "var1=value1&var2=value2" | regexFindAllNamed "(?P<param>\\w+)=(?P<value>\\w+)" 1 }} // Output: [map[param:var1 value:value1]]
+{{ "var1+value1" | regexFindAllNamed "(?P<param>\\w+)=(?P<value>\\w+)" -1 }} // Output: []
+{{ "var1=value1" | regexFindAllNamed "\\invalid$^///" -1 }} // Error
+```
+{% endtab %}
+{% endtabs %}

--- a/docs/registries/regexp.md
+++ b/docs/registries/regexp.md
@@ -7,6 +7,12 @@ description: >-
 
 # Regexp
 
+{% hint style="danger" %}
+This registry is **deprecated** and will be removed in Sprout v1.2. Use the [`regex`](regex.md) registry instead, where the main parameter is always the last one and every function can be used in a template pipeline.
+
+Both registries expose the same function names, so they are **mutually exclusive**: register one or the other, never both. See the [migration table](regex.md#regex) to know which four functions need their arguments to be reordered in your templates.
+{% endhint %}
+
 {% hint style="info" %}
 You can easily import all the functions from the <mark style="color:yellow;">`regexp`</mark> registry by including the following import statement in your code
 

--- a/group/all/all.go
+++ b/group/all/all.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-sprout/sprout/registry/numeric"
 	"github.com/go-sprout/sprout/registry/random"
 	"github.com/go-sprout/sprout/registry/reflect"
+	//nolint:staticcheck // kept until v1.2 to not break templates using the sprig signatures, will be swapped for `regex`
 	"github.com/go-sprout/sprout/registry/regexp"
 	"github.com/go-sprout/sprout/registry/semver"
 	"github.com/go-sprout/sprout/registry/slices"
@@ -27,6 +28,11 @@ import (
 // Included registries: checksum, conversion, encoding, env, filesystem, maps,
 // network, numeric, random, reflect, regexp, semver, slices, std, strings, time,
 // uniqueid.
+//
+// The deprecated `regexp` registry is still included to keep this group
+// non-breaking, it will be replaced by `regex` in Sprout v1.2. To opt in right
+// now, register [github.com/go-sprout/sprout/registry/regex] before this group,
+// its functions take precedence over the ones of `regexp`.
 func RegistryGroup() *sprout.RegistryGroup {
 	return sprout.NewRegistryGroup(
 		checksum.NewRegistry(),
@@ -39,7 +45,7 @@ func RegistryGroup() *sprout.RegistryGroup {
 		numeric.NewRegistry(),
 		random.NewRegistry(),
 		reflect.NewRegistry(),
-		regexp.NewRegistry(),
+		regexp.NewRegistry(), //nolint:staticcheck // see the note above about the v1.2 migration to `regex`
 		semver.NewRegistry(),
 		slices.NewRegistry(),
 		std.NewRegistry(),

--- a/group/hermetic/hermetic.go
+++ b/group/hermetic/hermetic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-sprout/sprout/registry/maps"
 	"github.com/go-sprout/sprout/registry/numeric"
 	"github.com/go-sprout/sprout/registry/reflect"
+	//nolint:staticcheck // kept until v1.2 to not break templates using the sprig signatures, will be swapped for `regex`
 	"github.com/go-sprout/sprout/registry/regexp"
 	"github.com/go-sprout/sprout/registry/semver"
 	"github.com/go-sprout/sprout/registry/slices"
@@ -23,6 +24,11 @@ import (
 //
 // Included registries: checksum, conversion, encoding, filesystem, maps, numeric,
 // reflect, regexp, semver, slices, std, strings, time, uniqueid.
+//
+// The deprecated `regexp` registry is still included to keep this group
+// non-breaking, it will be replaced by `regex` in Sprout v1.2. To opt in right
+// now, register [github.com/go-sprout/sprout/registry/regex] before this group,
+// its functions take precedence over the ones of `regexp`.
 func RegistryGroup() *sprout.RegistryGroup {
 	return sprout.NewRegistryGroup(
 		checksum.NewRegistry(),
@@ -32,7 +38,7 @@ func RegistryGroup() *sprout.RegistryGroup {
 		maps.NewRegistry(),
 		numeric.NewRegistry(),
 		reflect.NewRegistry(),
-		regexp.NewRegistry(),
+		regexp.NewRegistry(), //nolint:staticcheck // see the note above about the v1.2 migration to `regex`
 		semver.NewRegistry(),
 		slices.NewRegistry(),
 		std.NewRegistry(),

--- a/registry/regex/functions.go
+++ b/registry/regex/functions.go
@@ -1,0 +1,301 @@
+package regex
+
+import (
+	"regexp"
+)
+
+// RegexQuoteMeta returns a literal pattern string for the provided string.
+//
+// Parameters:
+//
+//	value string - the string to be escaped.
+//
+// Returns:
+//
+//	string - the escaped regex pattern.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexQuoteMeta].
+//
+// [Sprout Documentation: regexQuoteMeta]: https://docs.atom.codes/sprout/registries/regex#regexquotemeta
+func (rr *RegexRegistry) RegexQuoteMeta(value string) string {
+	return regexp.QuoteMeta(value)
+}
+
+// RegexFind searches for the first match of a regex pattern in a string
+// and returns it, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to search with.
+//	value string - the string to search within.
+//
+// Returns:
+//
+//	string - the first regex match found.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexFind].
+//
+// [Sprout Documentation: regexFind]: https://docs.atom.codes/sprout/registries/regex#regexfind
+func (rr *RegexRegistry) RegexFind(regex string, value string) (string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return "", err
+	}
+	return r.FindString(value), nil
+}
+
+// RegexFindAll finds all matches of a regex pattern in a string up to a
+// specified limit, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to search with.
+//	n int - the maximum number of matches to return; use -1 for no limit.
+//	value string - the string to search within.
+//
+// Returns:
+//
+//	[]string - all regex matches found.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexFindAll].
+//
+// [Sprout Documentation: regexFindAll]: https://docs.atom.codes/sprout/registries/regex#regexfindall
+func (rr *RegexRegistry) RegexFindAll(regex string, n int, value string) ([]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return []string{}, err
+	}
+	return r.FindAllString(value, n), nil
+}
+
+// RegexMatch checks if a string matches a regex pattern, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to match against.
+//	value string - the string to check.
+//
+// Returns:
+//
+//	bool - true if the string matches the regex pattern, otherwise false.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexMatch].
+//
+// [Sprout Documentation: regexMatch]: https://docs.atom.codes/sprout/registries/regex#regexmatch
+func (rr *RegexRegistry) RegexMatch(regex string, value string) (bool, error) {
+	return regexp.MatchString(regex, value)
+}
+
+// RegexSplit splits a string by a regex pattern up to a specified number of
+// substrings, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to split by.
+//	n int - the maximum number of substrings to return; use -1 for no limit.
+//	value string - the string to split.
+//
+// Returns:
+//
+//	[]string - the substrings resulting from the split.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexSplit].
+//
+// [Sprout Documentation: regexSplit]: https://docs.atom.codes/sprout/registries/regex#regexsplit
+func (rr *RegexRegistry) RegexSplit(regex string, n int, value string) ([]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return []string{}, err
+	}
+	return r.Split(value, n), nil
+}
+
+// RegexReplaceAll replaces all occurrences of a regex pattern in a string
+// with a replacement string, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to replace.
+//	replacedBy string - the replacement text.
+//	value string - the string containing the original text.
+//
+// Returns:
+//
+//	string - the modified string after all replacements.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexReplaceAll].
+//
+// [Sprout Documentation: regexReplaceAll]: https://docs.atom.codes/sprout/registries/regex#regexreplaceall
+func (rr *RegexRegistry) RegexReplaceAll(regex string, replacedBy string, value string) (string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return "", err
+	}
+	return r.ReplaceAllString(value, replacedBy), nil
+}
+
+// RegexReplaceAllLiteral replaces all occurrences of a regex pattern in a
+// string with a literal replacement string, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to replace.
+//	replacedBy string - the literal replacement text.
+//	value string - the string containing the original text.
+//
+// Returns:
+//
+//	string - the modified string after all replacements, treating the replacement text as literal text.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexReplaceAllLiteral].
+//
+// [Sprout Documentation: regexReplaceAllLiteral]: https://docs.atom.codes/sprout/registries/regex#regexreplaceallliteral
+func (rr *RegexRegistry) RegexReplaceAllLiteral(regex string, replacedBy string, value string) (string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return "", err
+	}
+	return r.ReplaceAllLiteralString(value, replacedBy), nil
+}
+
+// RegexFindGroups finds the first match of a regex pattern in a string and
+// returns the matched groups, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to search with.
+//	value string - the string to search within.
+//
+// Returns:
+//
+//	[]string - the matched groups from the first regex match found.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexFindGroups].
+//
+// [Sprout Documentation: regexFindGroups]: https://docs.atom.codes/sprout/registries/regex#regexfindgroups
+func (rr *RegexRegistry) RegexFindGroups(regex string, value string) ([]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return []string{}, err
+	}
+	matches := r.FindStringSubmatch(value)
+	if len(matches) == 0 {
+		return []string{}, nil
+	}
+	return matches, nil
+}
+
+// RegexFindAllGroups finds all matches of a regex pattern in a string up
+// to a specified limit and returns the matched groups, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to search with.
+//	n int - the maximum number of matches to return; use -1 for no limit.
+//	value string - the string to search within.
+//
+// Returns:
+//
+//	[][]string - a slice containing the matched groups for each match found.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexFindAllGroups].
+//
+// [Sprout Documentation: regexFindAllGroups]: https://docs.atom.codes/sprout/registries/regex#regexfindallgroups
+func (rr *RegexRegistry) RegexFindAllGroups(regex string, n int, value string) ([][]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return [][]string{}, err
+	}
+	matches := r.FindAllStringSubmatch(value, n)
+	if len(matches) == 0 {
+		return [][]string{}, nil
+	}
+	return matches, nil
+}
+
+// RegexFindNamed finds the first match of a regex pattern with named
+// capturing groups in a string and returns a map of group names to matched
+// strings, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to search with, containing named capturing groups.
+//	value string - the string to search within.
+//
+// Returns:
+//
+//	map[string]string - a map of group names to their corresponding matched strings.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexFindNamed].
+//
+// [Sprout Documentation: regexFindNamed]: https://docs.atom.codes/sprout/registries/regex#regexfindnamed
+func (rr *RegexRegistry) RegexFindNamed(regex string, value string) (map[string]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	matches := r.FindStringSubmatch(value)
+	if len(matches) == 0 {
+		return map[string]string{}, nil
+	}
+
+	result := make(map[string]string, len(r.SubexpNames())-1)
+	for i, name := range r.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = matches[i]
+		}
+	}
+	return result, nil
+}
+
+// RegexFindAllNamed finds all matches of a regex pattern with named capturing
+// groups in a string up to a specified limit and returns a slice of maps of
+// group names to matched strings, with error handling.
+//
+// Parameters:
+//
+//	regex string - the regular expression to search with, containing named capturing groups.
+//	n int - the maximum number of matches to return; use -1 for no limit.
+//	value string - the string to search within.
+//
+// Returns:
+//
+//	[]map[string]string - a slice containing a map of group names to their corresponding matched strings for each match found.
+//	error - error if the regex fails to compile.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: regexFindAllNamed].
+//
+// [Sprout Documentation: regexFindAllNamed]: https://docs.atom.codes/sprout/registries/regex#regexfindallnamed
+func (rr *RegexRegistry) RegexFindAllNamed(regex string, n int, value string) ([]map[string]string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return []map[string]string{}, err
+	}
+	matches := r.FindAllStringSubmatch(value, n)
+	if len(matches) == 0 {
+		return []map[string]string{}, nil
+	}
+
+	subexpNames := r.SubexpNames()
+	results := make([]map[string]string, 0, len(matches))
+
+	for _, match := range matches {
+		m := make(map[string]string, len(subexpNames))
+		for i, name := range subexpNames {
+			if i != 0 && name != "" {
+				m[name] = match[i]
+			}
+		}
+		results = append(results, m)
+	}
+	return results, nil
+}

--- a/registry/regex/functions_test.go
+++ b/registry/regex/functions_test.go
@@ -1,0 +1,204 @@
+package regex_test
+
+import (
+	"testing"
+
+	"github.com/go-sprout/sprout/pesticide"
+	"github.com/go-sprout/sprout/registry/regex"
+)
+
+func TestRegexFind(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestRegexFind", Input: `{{ "aaabbb" | regexFind "a(b+)" }}`, ExpectedOutput: "abbb"},
+		{Name: "TestRegexFindError", Input: `{{ "aaabbb" | regexFind "a(b+" }}`, ExpectedErr: "error parsing regexp"},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexFindAll(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestRegexFindAllWithoutLimit", Input: `{{ "aaabbb" | regexFindAll "a(b+)" -1 }}`, ExpectedOutput: "[abbb]"},
+		{Name: "TestRegexFindAllWithLimit", Input: `{{ "aaaabbb" | regexFindAll "a{2}" -1 }}`, ExpectedOutput: "[aa aa]"},
+		{Name: "TestRegexFindAllWithNoMatch", Input: `{{ "none" | regexFindAll "a{2}" -1 }}`, ExpectedOutput: "[]"},
+		{Name: "TestRegexFindAllWithInvalidPattern", Input: `{{ "aaabbb" | regexFindAll "a(b+" -1 }}`, ExpectedErr: "error parsing regexp"},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexMatch(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestRegexMatchValid", Input: `{{ "Hello" | regexMatch "^[a-zA-Z]+$" }}`, ExpectedOutput: "true"},
+		{Name: "TestRegexMatchInvalidAlphaNumeric", Input: `{{ "Hello123" | regexMatch "^[a-zA-Z]+$" }}`, ExpectedOutput: "false"},
+		{Name: "TestRegexMatchInvalidNumeric", Input: `{{ "123" | regexMatch "^[a-zA-Z]+$" }}`, ExpectedOutput: "false"},
+		{Name: "TestRegexMatchInvalidPattern", Input: `{{ "Hello" | regexMatch "^[a-zA+$" }}`, ExpectedErr: "error parsing regexp"},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexSplit(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestRegexSplitWithoutLimit", Input: `{{ "banana" | regexSplit "a" -1 }}`, ExpectedOutput: "[b n n ]"},
+		{Name: "TestRegexSplitZeroLimit", Input: `{{ "banana" | regexSplit "a" 0 }}`, ExpectedOutput: "[]"},
+		{Name: "TestRegexSplitOneLimit", Input: `{{ "banana" | regexSplit "a" 1 }}`, ExpectedOutput: "[banana]"},
+		{Name: "TestRegexSplitTwoLimit", Input: `{{ "banana" | regexSplit "a" 2 }}`, ExpectedOutput: "[b nana]"},
+		{Name: "TestRegexSplitRepetitionLimit", Input: `{{ "banana" | regexSplit "a+" 1 }}`, ExpectedOutput: "[banana]"},
+		{Name: "TestRegexSplitInvalidPattern", Input: `{{ "banana" | regexSplit "+" 0 }}`, ExpectedErr: "error parsing regexp"},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexReplaceAll(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestRegexReplaceAllValid", Input: `{{ "-ab-axxb-" | regexReplaceAll "a(x*)b" "T" }}`, ExpectedOutput: "-T-T-"},
+		{Name: "TestRegexReplaceAllWithDollarSign", Input: `{{ "-ab-axxb-" | regexReplaceAll "a(x*)b" "$1" }}`, ExpectedOutput: "--xx-"},
+		{Name: "TestRegexReplaceAllWithDollarSignAndLetter", Input: `{{ "-ab-axxb-" | regexReplaceAll "a(x*)b" "$1W" }}`, ExpectedOutput: "---"},
+		{Name: "TestRegexReplaceAllWithDollarSignAndCurlyBraces", Input: `{{ "-ab-axxb-" | regexReplaceAll "a(x*)b" "${1}W" }}`, ExpectedOutput: "-W-xxW-"},
+		{Name: "TestRegexReplaceAllWithInvalidPattern", Input: `{{ "-ab-axxb-" | regexReplaceAll "a(x*}" "T" }}`, ExpectedErr: "error parsing regexp"},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexReplaceAllLiteral(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestRegexReplaceAllLiteralValid", Input: `{{ "-ab-axxb-" | regexReplaceAllLiteral "a(x*)b" "T" }}`, ExpectedOutput: "-T-T-"},
+		{Name: "TestRegexReplaceAllLiteralWithDollarSign", Input: `{{ "-ab-axxb-" | regexReplaceAllLiteral "a(x*)b" "$1" }}`, ExpectedOutput: "-$1-$1-"},
+		{Name: "TestRegexReplaceAllLiteralWithDollarSignAndLetter", Input: `{{ "-ab-axxb-" | regexReplaceAllLiteral "a(x*)b" "$1W" }}`, ExpectedOutput: "-$1W-$1W-"},
+		{Name: "TestRegexReplaceAllLiteralWithDollarSignAndCurlyBraces", Input: `{{ "-ab-axxb-" | regexReplaceAllLiteral "a(x*)b" "${1}W" }}`, ExpectedOutput: "-${1}W-${1}W-"},
+		{Name: "TestRegexReplaceAllLiteralWithInvalidPattern", Input: `{{ "-ab-axxb-" | regexReplaceAllLiteral "a(x*}" "T" }}`, ExpectedErr: "error parsing regexp"},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexQuoteMeta(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestRegexQuoteMetaALongLine", Input: `{{ regexQuoteMeta "Escaping $100? That's a lot." }}`, ExpectedOutput: "Escaping \\$100\\? That's a lot\\."},
+		{Name: "TestRegexQuoteMetaASemVer", Input: `{{ regexQuoteMeta "1.2.3" }}`, ExpectedOutput: "1\\.2\\.3"},
+		{Name: "TestRegexQuoteMetaNothing", Input: `{{ regexQuoteMeta "golang" }}`, ExpectedOutput: "golang"},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexFindGroups(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{
+			Name:           "TestRegexFindGroupsValid",
+			Input:          `{{ .V | regexFindGroups "([A-Za-z]+)@(example\\.com)" }}`,
+			Data:           map[string]any{"V": "Contact us at support@example.com"},
+			ExpectedOutput: "[support@example.com support example.com]",
+		},
+		{
+			Name:           "TestRegexFindGroupsNoMatch",
+			Input:          `{{ .V | regexFindGroups "([A-Za-z]+)@(example\\.org)" }}`,
+			Data:           map[string]any{"V": "Contact us at support@example.com"},
+			ExpectedOutput: "[]",
+		},
+		{
+			Name:        "TestRegexFindGroupsInvalidPattern",
+			Input:       `{{ .V | regexFindGroups "([A-Za-z]+)@(example\\.com" }}`,
+			Data:        map[string]any{"V": "Contact us at support@example.com"},
+			ExpectedErr: "error parsing regexp",
+		},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexFindAllGroups(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{
+			Name:           "TestRegexFindAllGroupsValid",
+			Input:          `{{ .V | regexFindAllGroups "(\\w+)=(\\w+)" -1 }}`,
+			Data:           map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedOutput: "[[var1=value1 var1 value1] [var2=value2 var2 value2] [var3=value3 var3 value3]]",
+		},
+		{
+			Name:           "TestRegexFindAllGroupsWithLimit",
+			Input:          `{{ .V | regexFindAllGroups "(\\w+)=(\\w+)" 2 }}`,
+			Data:           map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedOutput: "[[var1=value1 var1 value1] [var2=value2 var2 value2]]",
+		},
+		{
+			Name:           "TestRegexFindAllGroupsNoMatch",
+			Input:          `{{ .V | regexFindAllGroups "(\\d+)=(\\d+)" -1 }}`,
+			Data:           map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedOutput: "[]",
+		},
+		{
+			Name:        "TestRegexFindAllGroupsInvalidPattern",
+			Input:       `{{ .V | regexFindAllGroups "(\\w+)=(\\w+" -1 }}`,
+			Data:        map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedErr: "error parsing regexp",
+		},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexFindNamed(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{
+			Name:           "TestRegexFindNamedValid",
+			Input:          `{{ .V | regexFindNamed "(?P<username>[A-Za-z]+)@(?P<domain>example\\.com)" }}`,
+			Data:           map[string]any{"V": "Contact us at noreply@example.com"},
+			ExpectedOutput: "map[domain:example.com username:noreply]",
+		},
+		{
+			Name:           "TestRegexFindNamedWithUnnamedGroup",
+			Input:          `{{ .V | regexFindNamed "(?P<username>[A-Za-z]+)@(example\\.com)" }}`,
+			Data:           map[string]any{"V": "Contact us at noreply@example.com"},
+			ExpectedOutput: "map[username:noreply]",
+		},
+		{
+			Name:           "TestRegexFindNamedNoMatch",
+			Input:          `{{ .V | regexFindNamed "(?P<username>[A-Za-z]+)@(?P<domain>example\\.org)" }}`,
+			Data:           map[string]any{"V": "Contact us at noreply@example.com"},
+			ExpectedOutput: "map[]",
+		},
+		{
+			Name:        "TestRegexFindNamedInvalidPattern",
+			Input:       `{{ .V | regexFindNamed "(?P<username>[A-Za-z]+)@(?P<domain>example\\.com" }}`,
+			Data:        map[string]any{"V": "Contact us at noreply@example.com"},
+			ExpectedErr: "error parsing regexp",
+		},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}
+
+func TestRegexFindAllNamed(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{
+			Name:           "TestRegexFindAllNamedValid",
+			Input:          `{{ .V | regexFindAllNamed "(?P<param>\\w+)=(?P<value>\\w+)" -1 }}`,
+			Data:           map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedOutput: "[map[param:var1 value:value1] map[param:var2 value:value2] map[param:var3 value:value3]]",
+		},
+		{
+			Name:           "TestRegexFindAllNamedWithLimit",
+			Input:          `{{ .V | regexFindAllNamed "(?P<param>\\w+)=(?P<value>\\w+)" 2 }}`,
+			Data:           map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedOutput: "[map[param:var1 value:value1] map[param:var2 value:value2]]",
+		},
+		{
+			Name:           "TestRegexFindAllNamedNoMatch",
+			Input:          `{{ .V | regexFindAllNamed "(?P<param>\\d+)=(?P<value>\\d+)" -1 }}`,
+			Data:           map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedOutput: "[]",
+		},
+		{
+			Name:        "TestRegexFindAllNamedInvalidPattern",
+			Input:       `{{ .V | regexFindAllNamed "(?P<param>\\w+)=(?P<value>\\w+" -1 }}`,
+			Data:        map[string]any{"V": "var1=value1&var2=value2&var3=value3"},
+			ExpectedErr: "error parsing regexp",
+		},
+	}
+
+	pesticide.RunTestCases(t, regex.NewRegistry(), tc)
+}

--- a/registry/regex/regex.go
+++ b/registry/regex/regex.go
@@ -1,0 +1,46 @@
+// Package regex provides regular expression functions where the main parameter
+// is always the last one, making every function usable in a template pipeline.
+//
+// It supersedes the [github.com/go-sprout/sprout/registry/regexp] registry,
+// which keeps the historical sprig signatures and is deprecated. Both
+// registries expose the same function names, so they are mutually exclusive:
+// register one or the other, never both.
+package regex
+
+import "github.com/go-sprout/sprout"
+
+type RegexRegistry struct {
+	handler sprout.Handler // Embedding Handler for shared functionality
+}
+
+// NewRegistry creates a new instance of regex registry.
+func NewRegistry() *RegexRegistry {
+	return &RegexRegistry{}
+}
+
+// UID returns the unique identifier of the registry.
+func (rr *RegexRegistry) UID() string {
+	return "go-sprout/sprout.regex"
+}
+
+// LinkHandler links the handler to the registry at runtime.
+func (rr *RegexRegistry) LinkHandler(fh sprout.Handler) error {
+	rr.handler = fh
+	return nil
+}
+
+// RegisterFunctions registers all functions of the registry.
+func (rr *RegexRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error {
+	sprout.AddFunction(funcsMap, "regexFind", rr.RegexFind)
+	sprout.AddFunction(funcsMap, "regexFindAll", rr.RegexFindAll)
+	sprout.AddFunction(funcsMap, "regexMatch", rr.RegexMatch)
+	sprout.AddFunction(funcsMap, "regexSplit", rr.RegexSplit)
+	sprout.AddFunction(funcsMap, "regexReplaceAll", rr.RegexReplaceAll)
+	sprout.AddFunction(funcsMap, "regexReplaceAllLiteral", rr.RegexReplaceAllLiteral)
+	sprout.AddFunction(funcsMap, "regexQuoteMeta", rr.RegexQuoteMeta)
+	sprout.AddFunction(funcsMap, "regexFindGroups", rr.RegexFindGroups)
+	sprout.AddFunction(funcsMap, "regexFindAllGroups", rr.RegexFindAllGroups)
+	sprout.AddFunction(funcsMap, "regexFindNamed", rr.RegexFindNamed)
+	sprout.AddFunction(funcsMap, "regexFindAllNamed", rr.RegexFindAllNamed)
+	return nil
+}

--- a/registry/regex/regex_test.go
+++ b/registry/regex/regex_test.go
@@ -1,0 +1,31 @@
+package regex_test
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-sprout/sprout"
+	"github.com/go-sprout/sprout/group/all"
+	"github.com/go-sprout/sprout/registry/regex"
+)
+
+// TestRegistryPrecedenceOverRegexp ensures the documented way to opt in the
+// `regex` registry while still using a group shipping the deprecated `regexp`
+// one works: functions are never overwritten, so the registry registered first
+// wins.
+func TestRegistryPrecedenceOverRegexp(t *testing.T) {
+	handler := sprout.New(
+		sprout.WithRegistries(regex.NewRegistry()),
+		sprout.WithGroups(all.RegistryGroup()),
+	)
+
+	tmpl, err := template.New("test").Funcs(handler.Build()).Parse(`{{ "banana" | regexSplit "a" -1 }}`)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, tmpl.Execute(&buf, nil))
+	require.Equal(t, "[b n n ]", buf.String())
+}

--- a/registry/regexp/regexp.go
+++ b/registry/regexp/regexp.go
@@ -1,3 +1,11 @@
+// Package regexp provides regular expression functions using the historical
+// sprig signatures, where the string to work on is not always the last
+// parameter.
+//
+// Deprecated: use [github.com/go-sprout/sprout/registry/regex] instead, where
+// the main parameter is always the last one and every function can be used in
+// a template pipeline. This registry is kept for backward compatibility and
+// will be removed in Sprout v1.2.
 package regexp
 
 import "github.com/go-sprout/sprout"
@@ -7,6 +15,10 @@ type RegexpRegistry struct {
 }
 
 // NewRegistry creates a new instance of regexp registry.
+//
+// Deprecated: use [github.com/go-sprout/sprout/registry/regex] NewRegistry
+// instead. Both registries expose the same function names, so they are mutually
+// exclusive: register one or the other, never both.
 func NewRegistry() *RegexpRegistry {
 	return &RegexpRegistry{}
 }
@@ -49,6 +61,24 @@ func (rr *RegexpRegistry) RegisterAliases(aliasesMap sprout.FunctionAliasMap) er
 }
 
 func (rr *RegexpRegistry) RegisterNotices(notices *[]sprout.FunctionNotice) error {
+	// The whole registry is deprecated in favor of the `regex` one, where the
+	// main parameter is always the last one. Functions whose signature is left
+	// untouched only need the registry to be swapped, the others also need the
+	// arguments to be reordered in the templates.
+	sprout.AddNotice(notices, sprout.NewNotice(sprout.NoticeKindDeprecated, []string{
+		"regexFind",
+		"regexMatch",
+		"regexQuoteMeta",
+		"regexFindGroups",
+		"regexFindAllGroups",
+		"regexFindNamed",
+		"regexFindAllNamed",
+	}, "the `regexp` registry is deprecated and will be removed in v1.2, please use the `regex` registry instead (this function keeps the same signature)"))
+	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("regexFindAll", "the `regexp` registry is deprecated and will be removed in v1.2, please use the `regex` registry instead where the signature becomes `regexFindAll <regex> <n> <value>`"))
+	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("regexSplit", "the `regexp` registry is deprecated and will be removed in v1.2, please use the `regex` registry instead where the signature becomes `regexSplit <regex> <n> <value>`"))
+	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("regexReplaceAll", "the `regexp` registry is deprecated and will be removed in v1.2, please use the `regex` registry instead where the signature becomes `regexReplaceAll <regex> <replacedBy> <value>`"))
+	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("regexReplaceAllLiteral", "the `regexp` registry is deprecated and will be removed in v1.2, please use the `regex` registry instead where the signature becomes `regexReplaceAllLiteral <regex> <replacedBy> <value>`"))
+
 	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("mustRegexFind", "please use `regexFind` instead"))
 	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("mustRegexFindAll", "please use `regexFindAll` instead"))
 	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("mustRegexMatch", "please use `regexMatch` instead"))

--- a/sprigin/sprig_backward_compatibility.go
+++ b/sprigin/sprig_backward_compatibility.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-sprout/sprout/registry/numeric"
 	"github.com/go-sprout/sprout/registry/random"
 	"github.com/go-sprout/sprout/registry/reflect"
+	//nolint:staticcheck // sprigin mirrors the sprig API, it must keep the sprig signatures of the `regexp` registry
 	"github.com/go-sprout/sprout/registry/regexp"
 	"github.com/go-sprout/sprout/registry/semver"
 	"github.com/go-sprout/sprout/registry/slices"
@@ -186,7 +187,7 @@ func (sh *SprigHandler) Build() sprout.FunctionMap {
 		conversion.NewRegistry(),
 		numeric.NewRegistry(),
 		encoding.NewRegistry(),
-		regexp.NewRegistry(),
+		regexp.NewRegistry(), //nolint:staticcheck // sprigin must keep the sprig signatures, it cannot use the `regex` registry
 		slices.NewRegistry(),
 		maps.NewRegistry(),
 		crypto.NewRegistry(),

--- a/tools/docvalidator/processing.go
+++ b/tools/docvalidator/processing.go
@@ -2,14 +2,36 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"text/template"
 
 	"github.com/go-sprout/sprout"
 	"github.com/go-sprout/sprout/group/all"
+	"github.com/go-sprout/sprout/registry/regex"
 )
 
 var sproutHandler = sprout.New(sprout.WithGroups(all.RegistryGroup()))
+
+// dedicatedHandlers associates a documentation file with its own handler. It is
+// needed for registries sharing their function names with a registry of the
+// `all` group, like `regex` and `regexp`, which cannot be registered together.
+// The dedicated registry is registered first so its functions take precedence.
+var dedicatedHandlers = map[string]*sprout.DefaultHandler{
+	filepath.Join("docs", "registries", "regex.md"): sprout.New(
+		sprout.WithRegistries(regex.NewRegistry()),
+		sprout.WithGroups(all.RegistryGroup()),
+	),
+}
+
+// handlerFor returns the handler to use to validate the examples of the given
+// documentation file, falling back to the default one built from all registries.
+func handlerFor(file string) *sprout.DefaultHandler {
+	if handler, ok := dedicatedHandlers[filepath.Clean(file)]; ok {
+		return handler
+	}
+	return sproutHandler
+}
 
 // processExample compiles and executes a single template example.
 // It checks the execution result against the expected output, and returns an error if they don't match.
@@ -20,7 +42,7 @@ func processExample(example Example) error {
 	}
 
 	// Build the template with custom functions
-	tmpl, err := template.New("example").Funcs(sproutHandler.Build()).Parse(example.Code)
+	tmpl, err := template.New("example").Funcs(handlerFor(example.File).Build()).Parse(example.Code)
 	if err != nil {
 		return fmt.Errorf("error parsing template: %w", err)
 	}

--- a/tools/docvalidator/processing_test.go
+++ b/tools/docvalidator/processing_test.go
@@ -1,10 +1,43 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestHandlerFor_Default tests handlerFor when the documentation file has no
+// dedicated handler. It verifies that the handler built from all registries is
+// returned.
+func TestHandlerFor_Default(t *testing.T) {
+	assert.Same(t, sproutHandler, handlerFor(filepath.Join("docs", "registries", "example1.md")))
+}
+
+// TestHandlerFor_Dedicated tests handlerFor when the documentation file has a
+// dedicated handler. It verifies that this handler is returned instead of the
+// default one, so the examples are validated against the right registry.
+func TestHandlerFor_Dedicated(t *testing.T) {
+	file := filepath.Join("docs", "registries", "regex.md")
+
+	handler := handlerFor(file)
+	assert.NotSame(t, sproutHandler, handler)
+	assert.Same(t, dedicatedHandlers[file], handler)
+}
+
+// TestProcessExample_DedicatedHandler tests processExample on a file having a
+// dedicated handler. The `regex` registry takes precedence over the deprecated
+// `regexp` one, so the main parameter is expected to be the last one.
+func TestProcessExample_DedicatedHandler(t *testing.T) {
+	example := Example{
+		FuncName: "regexSplit",
+		File:     filepath.Join("docs", "registries", "regex.md"),
+		Code:     `{{ "banana" | regexSplit "a" -1 }}`,
+		Expected: "[b n n ]",
+	}
+	err := processExample(example)
+	assert.NoError(t, err)
+}
 
 // TestProcessExample_Success tests processExample when the template executes
 // successfully and the output matches the expected output.


### PR DESCRIPTION
## Description

The main parameter to always be in last position so every function can be piped. As discussed in the issue, `regexp` cannot be fixed in place without breaking existing templates, so this PR implements **phase 1 of the agreed plan**: ship a new `regex` registry with pipe-friendly signatures and mark `regexp` as deprecated. Phase 2 (removing `regexp` and switching the groups over) lands in v1.2.

Nothing breaks: this release only adds a registry and emits deprecation warnings.

## Changes

**New `regex` registry** (`registry/regex`, UID `go-sprout/sprout.regex`) exposing the same 11 function names as `regexp`, with the string to work on always last. Only four signatures actually change:

| `regexp` (deprecated)                                 | `regex`                                               |
| ----------------------------------------------------- | ----------------------------------------------------- |
| `regexFindAll <regex> <value> <n>`                    | `regexFindAll <regex> <n> <value>`                    |
| `regexSplit <regex> <value> <n>`                      | `regexSplit <regex> <n> <value>`                      |
| `regexReplaceAll <regex> <value> <replacedBy>`        | `regexReplaceAll <regex> <replacedBy> <value>`        |
| `regexReplaceAllLiteral <regex> <value> <replacedBy>` | `regexReplaceAllLiteral <regex> <replacedBy> <value>` |

The seven others are untouched (`regexFindAllGroups` and `regexFindAllNamed` already had the right order). The `mustRegex*` aliases are not carried over: they are sprig legacy and already deprecated, so the new registry only implements `Registry`, neither `RegistryWithAlias` nor `RegistryWithNotice`.

**Deprecation of `regexp`**
- Go `Deprecated:` markers on the package and on `NewRegistry`, so staticcheck and IDEs flag library authors, who are the ones choosing the registry.
- Runtime notices on the 11 functions, worded per function: those keeping the same signature say so, the four others print their new signature.
  ```
  WARN Template function `regexFindAll` is deprecated: the `regexp` registry is deprecated and will be
  removed in v1.2, please use the `regex` registry instead where the signature becomes
  `regexFindAll <regex> <n> <value>`
  ```

**Groups left untouched.** `all` and `hermetic` keep `regexp` so this stays a non-breaking release; they switch to `regex` in v1.2. Both `RegistryGroup()` doc comments explain how to opt in today: register `regex` before the group. Since `AddFunction` never overwrites an existing function, the first one registered wins. That behavior is asserted by a test rather than just documented (`registry/regex/regex_test.go`). The three intentional consumers (`all`, `hermetic`, `sprigin`) carry a `//nolint:staticcheck` with the reason.
## Fixes

Part of #147 — phase 1 of 2. The issue should stay open until the `regexp` removal in v1.2.

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.