### PR TITLE
chore(sprigin): resolve ambiguity of signature warnings

### DIFF
--- a/docs/migration-from-sprig.md
+++ b/docs/migration-from-sprig.md
@@ -337,10 +337,28 @@ If you use `sprigin.FuncMap()`, both signatures are supported automatically. Spr
 
 | Function | Sprig Signature | Sprout Signature |
 |----------|-----------------|------------------|
-| `append` | `{{ append $list "value" }}` | `{{ $list \| append "value" }}` |
-| `prepend` | `{{ prepend $list "value" }}` | `{{ $list \| prepend "value" }}` |
+| `append` | `{{ $list = append $list "value" }}` | `{{ $list = $list \| append "value" }}` |
+| `prepend` | `{{ $list = prepend $list "value" }}` | `{{ $list = $list \| prepend "value" }}` |
 | `slice` | `{{ slice $list 1 3 }}` | `{{ $list \| slice 1 3 }}` |
 | `without` | `{{ without $list "a" "b" }}` | `{{ $list \| without "a" "b" }}` |
+
+{% hint style="warning" %}
+`append` and `prepend` return a **new** list, they never modify the one they receive. Accumulating in a `range` therefore requires assigning the result back, in Sprig as well as in Sprout. Only the position of the arguments changes:
+
+```go
+{{- $stages := list -}}
+{{- range .Stages -}}
+  {{- $stages = $stages | append .Name -}}
+{{- end -}}
+{{ $stages | sortAlpha }}
+```
+
+Dropping the `=` leaves `$stages` empty and prints the intermediate lists into the output:
+
+```go
+{{- $stages | append .Name -}} {{/* the result goes to the output, $stages is unchanged */}}
+```
+{% endhint %}
 
 #### Dig Function
 

--- a/docs/registries/slices.md
+++ b/docs/registries/slices.md
@@ -46,6 +46,18 @@ The function adds an element to the end of an existing list, extending the list 
 {% endtab %}
 {% endtabs %}
 
+{% hint style="warning" %}
+The list you pass in is never modified, a new one is returned. To accumulate in a `range`, assign the result back:
+
+<pre class="language-go"><code class="lang-go">{{- $stages := list -}}
+{{- range .Stages -}}
+  {{- $stages = $stages | append .Name -}}
+{{- end -}}
+</code></pre>
+
+Without the `=`, the list stays empty and each intermediate result is printed into the output.
+{% endhint %}
+
 ### <mark style="color:purple;">prepend</mark>
 
 The function adds an element to the beginning of an existing list, placing the new item before all others.
@@ -61,6 +73,10 @@ The function adds an element to the beginning of an existing list, placing the n
 ```
 {% endtab %}
 {% endtabs %}
+
+{% hint style="warning" %}
+Like `append`, the list you pass in is never modified: assign the result back to accumulate it.
+{% endhint %}
 
 ### <mark style="color:purple;">concat</mark>
 

--- a/registry/slices/functions.go
+++ b/registry/slices/functions.go
@@ -73,7 +73,7 @@ func (sr *SlicesRegistry) Append(v any, list any) ([]any, error) {
 		return result, nil
 
 	default:
-		return nil, fmt.Errorf("cannot append on type %s", tp)
+		return nil, fmt.Errorf("cannot append on type %s, the list must be the last argument", tp)
 	}
 }
 
@@ -111,7 +111,7 @@ func (sr *SlicesRegistry) Prepend(v any, list any) ([]any, error) {
 		return append([]any{v}, result...), nil
 
 	default:
-		return nil, fmt.Errorf("cannot prepend on type %s", tp)
+		return nil, fmt.Errorf("cannot prepend on type %s, the list must be the last argument", tp)
 	}
 }
 

--- a/registry/slices/functions_test.go
+++ b/registry/slices/functions_test.go
@@ -24,6 +24,7 @@ func TestAppend(t *testing.T) {
 		{Input: `{{ .V | append "a" }}`, ExpectedOutput: "[x a]", Data: map[string]any{"V": [1]string{"x"}}},
 		{Input: `{{ .V | append "a" }}`, Data: map[string]any{"V": nil}, ExpectedErr: "cannot append to nil"},
 		{Input: `{{ .V | append "a" }}`, Data: map[string]any{"V": 1}, ExpectedErr: "cannot append on type int"},
+		{Name: "TestWithTheListFirst", Input: `{{ append .V "a" }}`, Data: map[string]any{"V": []string{"x"}}, ExpectedErr: "cannot append on type string, the list must be the last argument"},
 		{Input: `{{ append }}`, ExpectedErr: "wrong number of args for append: want 2 got 0"},
 	}
 
@@ -38,6 +39,7 @@ func TestPrepend(t *testing.T) {
 		{Input: `{{ .V | prepend "a" }}`, ExpectedOutput: "[a x]", Data: map[string]any{"V": [1]string{"x"}}},
 		{Input: `{{ .V | prepend "a" }}`, Data: map[string]any{"V": nil}, ExpectedErr: "cannot prepend to nil"},
 		{Input: `{{ .V | prepend "a" }}`, Data: map[string]any{"V": 1}, ExpectedErr: "cannot prepend on type int"},
+		{Name: "TestWithTheListFirst", Input: `{{ prepend .V "a" }}`, Data: map[string]any{"V": []string{"x"}}, ExpectedErr: "cannot prepend on type string, the list must be the last argument"},
 		{Input: `{{ prepend }}`, ExpectedErr: "wrong number of args for prepend: want 2 got 0"},
 	}
 

--- a/sprigin/signature_warn_test.go
+++ b/sprigin/signature_warn_test.go
@@ -1,0 +1,132 @@
+package sprigin
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	ttemplate "text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderWithLogger executes tmpl with a func map logging to a buffer, and
+// returns everything the handler logged while rendering.
+func renderWithLogger(t *testing.T, tmpl string) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tpl, err := ttemplate.New("warn").Funcs(FuncMapWith(WithLogger(bufferedLogger(&buf)))).Parse(tmpl)
+	require.NoError(t, err)
+	require.NoError(t, tpl.Execute(io.Discard, nil))
+
+	return buf.String()
+}
+
+func TestSignatureWarn(t *testing.T) {
+	var buf bytes.Buffer
+
+	handler := NewSprigHandler()
+	require.NoError(t, WithLogger(bufferedLogger(&buf))(handler))
+
+	handler.SignatureWarn("append", sprigSignAppend, sproutSignAppend)
+
+	// slog escapes the quotes of the message, so the assertions use the parts of
+	// the signatures that carry no quote.
+	logged := buf.String()
+	assert.Contains(t, logged, "The signature of `append` has changed")
+	assert.Contains(t, logged, "{{ $list = append $list")
+	assert.Contains(t, logged, "{{ $list = $list | append")
+}
+
+func TestAmbiguousSignatureWarn(t *testing.T) {
+	var buf bytes.Buffer
+
+	handler := NewSprigHandler()
+	require.NoError(t, WithLogger(bufferedLogger(&buf))(handler))
+
+	handler.AmbiguousSignatureWarn("append", sprigSignAppend, sproutSignAppend)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "Template function `append` is ambiguous")
+	assert.Contains(t, logged, "match both signatures")
+	assert.Contains(t, logged, "use the `sprout` package directly")
+	// The migration wording must not be used here, the caller may already be on
+	// the sprout signature.
+	assert.NotContains(t, logged, "has changed")
+}
+
+// TestSignatureWarnShowsTheAssignment covers the confusion reported in #180:
+// the migration message used to show calls without assignment, which reads as
+// if the call alone was enough to accumulate in a `range`.
+func TestSignatureWarnShowsTheAssignment(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		tmpl     string
+		expected string
+	}{
+		// slog escapes the quotes of the message, so the expectation stops before
+		// the quoted value.
+		{"append", `{{ $l := list "a" }}{{ $l = append $l "b" }}`, `{{ $list = $list | append`},
+		{"prepend", `{{ $l := list "a" }}{{ $l = prepend $l "b" }}`, `{{ $list = $list | prepend`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := renderWithLogger(t, tc.tmpl)
+
+			assert.Contains(t, logged, "has changed")
+			assert.Contains(t, logged, tc.expected)
+		})
+	}
+}
+
+// TestAmbiguousCallsWarnAsAmbiguous ensures a call whose arguments match both
+// signatures is reported as ambiguous instead of being told to migrate to the
+// signature it may already use.
+func TestAmbiguousCallsWarnAsAmbiguous(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tmpl string
+	}{
+		{"append two lists", `{{ $a := list "a" }}{{ $b := list "b" }}{{ $a | append $b }}`},
+		{"prepend two lists", `{{ $a := list "a" }}{{ $b := list "b" }}{{ $a | prepend $b }}`},
+		{"without two lists", `{{ $a := list "a" }}{{ $b := list "b" }}{{ $a | without $b }}`},
+		{"set two dicts", `{{ $a := dict "a" 1 }}{{ $b := dict "b" 2 }}{{ set $a "key" $b }}`},
+		{"get two dicts", `{{ $a := dict "a" 1 }}{{ $b := dict "b" 2 }}{{ get $a $b }}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := renderWithLogger(t, tc.tmpl)
+
+			assert.Contains(t, logged, "is ambiguous")
+			assert.NotContains(t, logged, "has changed")
+		})
+	}
+}
+
+// TestUndecidableCallsDoNotWarn ensures a call with no receiver at all is left
+// to the registry error handling, without a misleading migration message.
+func TestUndecidableCallsDoNotWarn(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tmpl string
+	}{
+		{"append without a list", `{{ append "a" "b" }}`},
+		{"prepend without a list", `{{ prepend "a" "b" }}`},
+		{"get without a dict", `{{ get "a" "b" }}`},
+		{"hasKey without a dict", `{{ hasKey "a" "b" }}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := renderWithLogger(t, tc.tmpl)
+
+			assert.NotContains(t, logged, "has changed")
+			assert.NotContains(t, logged, "is ambiguous")
+		})
+	}
+}
+
+// TestSproutSignatureStaysSilent ensures a template already using the sprout
+// signature is not warned about anything.
+func TestSproutSignatureStaysSilent(t *testing.T) {
+	logged := renderWithLogger(t, `{{ $l := list "a" }}{{ $l = $l | append "b" }}{{ $l | without "a" }}`)
+
+	assert.Empty(t, logged)
+}

--- a/sprigin/signature_warn_test.go
+++ b/sprigin/signature_warn_test.go
@@ -51,6 +51,7 @@ func TestAmbiguousSignatureWarn(t *testing.T) {
 	assert.Contains(t, logged, "Template function `append` is ambiguous")
 	assert.Contains(t, logged, "match both signatures")
 	assert.Contains(t, logged, "use the `sprout` package directly")
+	assert.Contains(t, logged, "notice=deprecated")
 	// The migration wording must not be used here, the caller may already be on
 	// the sprout signature.
 	assert.NotContains(t, logged, "has changed")

--- a/sprigin/sprig_backward_compatibility.go
+++ b/sprigin/sprig_backward_compatibility.go
@@ -151,10 +151,30 @@ func (sh *SprigHandler) Logger() *slog.Logger {
 // SignatureWarn logs a warning message about a deprecated function signature.
 // This is used to warn users when they use the old Sprig signature instead of
 // the new Sprout signature.
+//
+// oldSign and newSign are shown side by side, so they must differ only by what
+// the user has to change. For the functions returning a new value that is
+// usually accumulated, both should carry the assignment, otherwise the message
+// reads as if the call alone was enough.
 func (sh *SprigHandler) SignatureWarn(functionName, oldSign, newSign string) {
 	msg := fmt.Sprintf("The signature of `%s` has changed from `%s` to `%s`, please update your code before next upgrade. This change will simplify the usage of the function and respect go/template conventions and allow usage of pipe (`|`).", functionName, oldSign, newSign)
 
 	sh.Logger().With("function", functionName, "notice", "deprecated").Warn(fmt.Sprintf("Template function `%s` is deprecated: %s", functionName, msg))
+}
+
+// AmbiguousSignatureWarn logs a warning message when the arguments of a call
+// match both the Sprig and the Sprout signatures, which happens when the
+// receiver and the value have the same type, e.g. appending a list to a list.
+//
+// The call cannot be disambiguated from the arguments alone, so the Sprig
+// signature is assumed for backward compatibility. Callers already migrated to
+// the Sprout signature get their arguments swapped, hence a message of its own
+// instead of the migration one, which would tell them to move to the very
+// signature they already use.
+func (sh *SprigHandler) AmbiguousSignatureWarn(functionName, assumedSign, migratedSign string) {
+	msg := fmt.Sprintf("The arguments of `%s` match both signatures, the sprig one `%s` has been assumed. If your template already uses `%s`, its arguments have been swapped: use the `sprout` package directly, where only the sprout signature exists, to remove the ambiguity.", functionName, assumedSign, migratedSign)
+
+	sh.Logger().With("function", functionName, "notice", "ambiguous").Warn(fmt.Sprintf("Template function `%s` is ambiguous: %s", functionName, msg))
 }
 
 func (sh *SprigHandler) BreakingWarn(functionName, changeNotice string) {

--- a/sprigin/sprig_backward_compatibility.go
+++ b/sprigin/sprig_backward_compatibility.go
@@ -174,7 +174,7 @@ func (sh *SprigHandler) SignatureWarn(functionName, oldSign, newSign string) {
 func (sh *SprigHandler) AmbiguousSignatureWarn(functionName, assumedSign, migratedSign string) {
 	msg := fmt.Sprintf("The arguments of `%s` match both signatures, the sprig one `%s` has been assumed. If your template already uses `%s`, its arguments have been swapped: use the `sprout` package directly, where only the sprout signature exists, to remove the ambiguity.", functionName, assumedSign, migratedSign)
 
-	sh.Logger().With("function", functionName, "notice", "ambiguous").Warn(fmt.Sprintf("Template function `%s` is ambiguous: %s", functionName, msg))
+	sh.Logger().With("function", functionName, "notice", "deprecated").Warn(fmt.Sprintf("Template function `%s` is ambiguous: %s", functionName, msg))
 }
 
 func (sh *SprigHandler) BreakingWarn(functionName, changeNotice string) {

--- a/sprigin/sprig_functions.go
+++ b/sprigin/sprig_functions.go
@@ -43,6 +43,37 @@ func isMap(v any) bool {
 // These wrappers are only used through the sprigin compatibility layer.
 // Deprecation warnings are only logged when old Sprig signature is detected.
 
+// Signatures displayed by [SprigHandler.SignatureWarn] and
+// [SprigHandler.AmbiguousSignatureWarn]. They are defined once per function so
+// both messages always show the very same forms.
+//
+// `append` and `prepend` carry the assignment because they return a new list
+// without mutating the original one: showing the call alone reads as if it was
+// enough to accumulate in a `range`, which it is not.
+const (
+	sprigSignGet     = `{{ get $dict "key" }}`
+	sproutSignGet    = `{{ $dict | get "key" }}`
+	sprigSignSet     = `{{ set $dict "key" "value" }}`
+	sproutSignSet    = `{{ $dict | set "key" "value" }}`
+	sprigSignUnset   = `{{ unset $dict "key" }}`
+	sproutSignUnset  = `{{ $dict | unset "key" }}`
+	sprigSignHasKey  = `{{ hasKey $dict "key" }}`
+	sproutSignHasKey = `{{ $dict | hasKey "key" }}`
+	sprigSignPick    = `{{ pick $dict "key1" "key2" }}`
+	sproutSignPick   = `{{ $dict | pick "key1" "key2" }}`
+	sprigSignOmit    = `{{ omit $dict "key1" "key2" }}`
+	sproutSignOmit   = `{{ $dict | omit "key1" "key2" }}`
+
+	sprigSignAppend   = `{{ $list = append $list "value" }}`
+	sproutSignAppend  = `{{ $list = $list | append "value" }}`
+	sprigSignPrepend  = `{{ $list = prepend $list "value" }}`
+	sproutSignPrepend = `{{ $list = $list | prepend "value" }}`
+	sprigSignSlice    = `{{ slice $list 1 3 }}`
+	sproutSignSlice   = `{{ $list | slice 1 3 }}`
+	sprigSignWithout  = `{{ without $list "a" "b" }}`
+	sproutSignWithout = `{{ $list | without "a" "b" }}`
+)
+
 // sprigGet handles both Sprig and Sprout signatures for get.
 // Sprig: get(dict, key) - dict first
 // Sprout: get(key, dict) - dict last (for piping)
@@ -59,7 +90,7 @@ func (sh *SprigHandler) sprigGet(mr *maps.MapsRegistry) func(args ...any) (any, 
 		switch {
 		case firstIsMap && !secondIsMap:
 			// Old Sprig signature: get(dict, key)
-			sh.SignatureWarn("get", "{{ get $dict \"key\" }}", "{{ $dict | get \"key\" }}")
+			sh.SignatureWarn("get", sprigSignGet, sproutSignGet)
 			dict := args[0].(map[string]any)
 			key, ok := args[1].(string)
 			if !ok {
@@ -75,8 +106,12 @@ func (sh *SprigHandler) sprigGet(mr *maps.MapsRegistry) func(args ...any) (any, 
 			dict := args[1].(map[string]any)
 			return mr.Get(key, dict)
 		default:
-			// Ambiguous or invalid - try Sprig behavior (with warning)
-			sh.SignatureWarn("get", "{{ get $dict \"key\" }}", "{{ $dict | get \"key\" }}")
+			// Both are maps, or neither is: the signature cannot be told apart,
+			// keep the Sprig behavior for backward compatibility. Only warn when
+			// the call is truly ambiguous, otherwise it is an argument error.
+			if firstIsMap && secondIsMap {
+				sh.AmbiguousSignatureWarn("get", sprigSignGet, sproutSignGet)
+			}
 			dict, ok := args[0].(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("first argument must be a map[string]any")
@@ -106,7 +141,7 @@ func (sh *SprigHandler) sprigSet(mr *maps.MapsRegistry) func(args ...any) (map[s
 		switch {
 		case firstIsMap && !lastIsMap:
 			// Old Sprig signature: set(dict, key, value)
-			sh.SignatureWarn("set", "{{ set $dict \"key\" \"value\" }}", "{{ $dict | set \"key\" \"value\" }}")
+			sh.SignatureWarn("set", sprigSignSet, sproutSignSet)
 			dict := args[0].(map[string]any)
 			key, ok := args[1].(string)
 			if !ok {
@@ -124,8 +159,13 @@ func (sh *SprigHandler) sprigSet(mr *maps.MapsRegistry) func(args ...any) (map[s
 			dict := args[2].(map[string]any)
 			return mr.Set(key, value, dict)
 		default:
-			// Ambiguous - try Sprig behavior (with warning)
-			sh.SignatureWarn("set", "{{ set $dict \"key\" \"value\" }}", "{{ $dict | set \"key\" \"value\" }}")
+			// Both ends are maps, or neither is: the signature cannot be told
+			// apart, keep the Sprig behavior for backward compatibility. Only
+			// warn when the call is truly ambiguous, otherwise it is an
+			// argument error.
+			if firstIsMap && lastIsMap {
+				sh.AmbiguousSignatureWarn("set", sprigSignSet, sproutSignSet)
+			}
 			dict, ok := args[0].(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("first argument must be a map[string]any")
@@ -156,7 +196,7 @@ func (sh *SprigHandler) sprigUnset(mr *maps.MapsRegistry) func(args ...any) (map
 		switch {
 		case firstIsMap && !secondIsMap:
 			// Old Sprig signature: unset(dict, key)
-			sh.SignatureWarn("unset", "{{ unset $dict \"key\" }}", "{{ $dict | unset \"key\" }}")
+			sh.SignatureWarn("unset", sprigSignUnset, sproutSignUnset)
 			dict := args[0].(map[string]any)
 			key, ok := args[1].(string)
 			if !ok {
@@ -172,8 +212,12 @@ func (sh *SprigHandler) sprigUnset(mr *maps.MapsRegistry) func(args ...any) (map
 			dict := args[1].(map[string]any)
 			return mr.Unset(key, dict)
 		default:
-			// Ambiguous - try Sprig behavior (with warning)
-			sh.SignatureWarn("unset", "{{ unset $dict \"key\" }}", "{{ $dict | unset \"key\" }}")
+			// Both are maps, or neither is: the signature cannot be told apart,
+			// keep the Sprig behavior for backward compatibility. Only warn when
+			// the call is truly ambiguous, otherwise it is an argument error.
+			if firstIsMap && secondIsMap {
+				sh.AmbiguousSignatureWarn("unset", sprigSignUnset, sproutSignUnset)
+			}
 			dict, ok := args[0].(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("first argument must be a map[string]any")
@@ -203,7 +247,7 @@ func (sh *SprigHandler) sprigHasKey(mr *maps.MapsRegistry) func(args ...any) (bo
 		switch {
 		case firstIsMap && !secondIsMap:
 			// Old Sprig signature: hasKey(dict, key)
-			sh.SignatureWarn("hasKey", "{{ hasKey $dict \"key\" }}", "{{ $dict | hasKey \"key\" }}")
+			sh.SignatureWarn("hasKey", sprigSignHasKey, sproutSignHasKey)
 			dict := args[0].(map[string]any)
 			key, ok := args[1].(string)
 			if !ok {
@@ -219,8 +263,12 @@ func (sh *SprigHandler) sprigHasKey(mr *maps.MapsRegistry) func(args ...any) (bo
 			dict := args[1].(map[string]any)
 			return mr.HasKey(key, dict)
 		default:
-			// Ambiguous - try Sprig behavior (with warning)
-			sh.SignatureWarn("hasKey", "{{ hasKey $dict \"key\" }}", "{{ $dict | hasKey \"key\" }}")
+			// Both are maps, or neither is: the signature cannot be told apart,
+			// keep the Sprig behavior for backward compatibility. Only warn when
+			// the call is truly ambiguous, otherwise it is an argument error.
+			if firstIsMap && secondIsMap {
+				sh.AmbiguousSignatureWarn("hasKey", sprigSignHasKey, sproutSignHasKey)
+			}
 			dict, ok := args[0].(map[string]any)
 			if !ok {
 				return false, fmt.Errorf("first argument must be a map[string]any")
@@ -251,7 +299,7 @@ func (sh *SprigHandler) sprigPick(mr *maps.MapsRegistry) func(args ...any) (map[
 		case firstIsMap && !lastIsMap:
 			// Old Sprig signature: pick(dict, keys...)
 			// Convert to Sprout: pick(keys..., dict)
-			sh.SignatureWarn("pick", "{{ pick $dict \"key1\" \"key2\" }}", "{{ $dict | pick \"key1\" \"key2\" }}")
+			sh.SignatureWarn("pick", sprigSignPick, sproutSignPick)
 			dict := args[0]
 			keys := args[1:]
 			return mr.Pick(append(keys, dict)...)
@@ -260,8 +308,13 @@ func (sh *SprigHandler) sprigPick(mr *maps.MapsRegistry) func(args ...any) (map[
 			// Already in correct order
 			return mr.Pick(args...)
 		default:
-			// Ambiguous - default to Sprig behavior (with warning)
-			sh.SignatureWarn("pick", "{{ pick $dict \"key1\" \"key2\" }}", "{{ $dict | pick \"key1\" \"key2\" }}")
+			// Both ends are maps, or neither is: the signature cannot be told
+			// apart, keep the Sprig behavior for backward compatibility. Only
+			// warn when the call is truly ambiguous, otherwise it is an
+			// argument error.
+			if firstIsMap && lastIsMap {
+				sh.AmbiguousSignatureWarn("pick", sprigSignPick, sproutSignPick)
+			}
 			dict := args[0]
 			keys := args[1:]
 			return mr.Pick(append(keys, dict)...)
@@ -289,7 +342,7 @@ func (sh *SprigHandler) sprigOmit(mr *maps.MapsRegistry) func(args ...any) (map[
 		case firstIsMap && !lastIsMap:
 			// Old Sprig signature: omit(dict, keys...)
 			// Convert to Sprout: omit(keys..., dict)
-			sh.SignatureWarn("omit", "{{ omit $dict \"key1\" \"key2\" }}", "{{ $dict | omit \"key1\" \"key2\" }}")
+			sh.SignatureWarn("omit", sprigSignOmit, sproutSignOmit)
 			dict := args[0]
 			keys := args[1:]
 			return mr.Omit(append(keys, dict)...)
@@ -298,8 +351,13 @@ func (sh *SprigHandler) sprigOmit(mr *maps.MapsRegistry) func(args ...any) (map[
 			// Already in correct order
 			return mr.Omit(args...)
 		default:
-			// Ambiguous - default to Sprig behavior (with warning)
-			sh.SignatureWarn("omit", "{{ omit $dict \"key1\" \"key2\" }}", "{{ $dict | omit \"key1\" \"key2\" }}")
+			// Both ends are maps, or neither is: the signature cannot be told
+			// apart, keep the Sprig behavior for backward compatibility. Only
+			// warn when the call is truly ambiguous, otherwise it is an
+			// argument error.
+			if firstIsMap && lastIsMap {
+				sh.AmbiguousSignatureWarn("omit", sprigSignOmit, sproutSignOmit)
+			}
 			dict := args[0]
 			keys := args[1:]
 			return mr.Omit(append(keys, dict)...)
@@ -359,14 +417,19 @@ func (sh *SprigHandler) sprigAppend(sr *slices.SlicesRegistry) func(args ...any)
 		switch {
 		case firstIsList && !secondIsList:
 			// Old Sprig signature: append(list, value)
-			sh.SignatureWarn("append", "{{ append $list \"value\" }}", "{{ $list | append \"value\" }}")
+			sh.SignatureWarn("append", sprigSignAppend, sproutSignAppend)
 			return sr.Append(second, first)
 		case !firstIsList && secondIsList:
 			// New Sprout signature: append(value, list)
 			return sr.Append(first, second)
+		case firstIsList && secondIsList:
+			// Both are lists, the signature cannot be told apart: keep the Sprig
+			// behavior for backward compatibility and say so.
+			sh.AmbiguousSignatureWarn("append", sprigSignAppend, sproutSignAppend)
+			return sr.Append(second, first)
 		default:
-			// Ambiguous or neither is list - default to Sprig behavior (with warning)
-			sh.SignatureWarn("append", "{{ append $list \"value\" }}", "{{ $list | append \"value\" }}")
+			// Neither is a list: this is an argument error, not a signature one,
+			// let the registry report it.
 			return sr.Append(second, first)
 		}
 	}
@@ -390,14 +453,19 @@ func (sh *SprigHandler) sprigPrepend(sr *slices.SlicesRegistry) func(args ...any
 		switch {
 		case firstIsList && !secondIsList:
 			// Old Sprig signature: prepend(list, value)
-			sh.SignatureWarn("prepend", "{{ prepend $list \"value\" }}", "{{ $list | prepend \"value\" }}")
+			sh.SignatureWarn("prepend", sprigSignPrepend, sproutSignPrepend)
 			return sr.Prepend(second, first)
 		case !firstIsList && secondIsList:
 			// New Sprout signature: prepend(value, list)
 			return sr.Prepend(first, second)
+		case firstIsList && secondIsList:
+			// Both are lists, the signature cannot be told apart: keep the Sprig
+			// behavior for backward compatibility and say so.
+			sh.AmbiguousSignatureWarn("prepend", sprigSignPrepend, sproutSignPrepend)
+			return sr.Prepend(second, first)
 		default:
-			// Ambiguous or neither is list - default to Sprig behavior (with warning)
-			sh.SignatureWarn("prepend", "{{ prepend $list \"value\" }}", "{{ $list | prepend \"value\" }}")
+			// Neither is a list: this is an argument error, not a signature one,
+			// let the registry report it.
 			return sr.Prepend(second, first)
 		}
 	}
@@ -424,7 +492,7 @@ func (sh *SprigHandler) sprigSlice(sr *slices.SlicesRegistry) func(args ...any) 
 		case firstIsList && !lastIsList:
 			// Old Sprig signature: slice(list, indices...)
 			// Convert to Sprout: slice(indices..., list)
-			sh.SignatureWarn("slice", "{{ slice $list 1 3 }}", "{{ $list | slice 1 3 }}")
+			sh.SignatureWarn("slice", sprigSignSlice, sproutSignSlice)
 			list := args[0]
 			indices := args[1:]
 			return sr.Slice(append(indices, list)...)
@@ -432,9 +500,16 @@ func (sh *SprigHandler) sprigSlice(sr *slices.SlicesRegistry) func(args ...any) 
 			// New Sprout signature: slice(indices..., list)
 			// Already in correct order
 			return sr.Slice(args...)
+		case firstIsList && lastIsList:
+			// Both ends are lists, the signature cannot be told apart: keep the
+			// Sprig behavior for backward compatibility and say so.
+			sh.AmbiguousSignatureWarn("slice", sprigSignSlice, sproutSignSlice)
+			list := args[0]
+			indices := args[1:]
+			return sr.Slice(append(indices, list)...)
 		default:
-			// Ambiguous - default to Sprig behavior (with warning)
-			sh.SignatureWarn("slice", "{{ slice $list 1 3 }}", "{{ $list | slice 1 3 }}")
+			// No list at either end: this is an argument error, not a signature
+			// one, let the registry report it.
 			list := args[0]
 			indices := args[1:]
 			return sr.Slice(append(indices, list)...)
@@ -459,7 +534,7 @@ func (sh *SprigHandler) sprigWithout(sr *slices.SlicesRegistry) func(args ...any
 		case firstIsList && !lastIsList:
 			// Old Sprig signature: without(list, omit...)
 			// Convert to Sprout: without(omit..., list)
-			sh.SignatureWarn("without", "{{ without $list \"a\" \"b\" }}", "{{ $list | without \"a\" \"b\" }}")
+			sh.SignatureWarn("without", sprigSignWithout, sproutSignWithout)
 			list := args[0]
 			omit := args[1:]
 			return sr.Without(append(omit, list)...)
@@ -467,9 +542,16 @@ func (sh *SprigHandler) sprigWithout(sr *slices.SlicesRegistry) func(args ...any
 			// New Sprout signature: without(omit..., list)
 			// Already in correct order
 			return sr.Without(args...)
+		case firstIsList && lastIsList:
+			// Both ends are lists, the signature cannot be told apart: keep the
+			// Sprig behavior for backward compatibility and say so.
+			sh.AmbiguousSignatureWarn("without", sprigSignWithout, sproutSignWithout)
+			list := args[0]
+			omit := args[1:]
+			return sr.Without(append(omit, list)...)
 		default:
-			// Ambiguous - default to Sprig behavior (with warning)
-			sh.SignatureWarn("without", "{{ without $list \"a\" \"b\" }}", "{{ $list | without \"a\" \"b\" }}")
+			// No list at either end: this is an argument error, not a signature
+			// one, let the registry report it.
 			list := args[0]
 			omit := args[1:]
 			return sr.Without(append(omit, list)...)

--- a/sprigin/sprig_functions.go
+++ b/sprigin/sprig_functions.go
@@ -106,9 +106,9 @@ func (sh *SprigHandler) sprigGet(mr *maps.MapsRegistry) func(args ...any) (any, 
 			dict := args[1].(map[string]any)
 			return mr.Get(key, dict)
 		default:
-			// Both are maps, or neither is: the signature cannot be told apart,
-			// keep the Sprig behavior for backward compatibility. Only warn when
-			// the call is truly ambiguous, otherwise it is an argument error.
+			// Both are maps, or neither is: keep the Sprig behavior. Only the
+			// former is a signature ambiguity, the latter is an argument error
+			// the registry reports on its own.
 			if firstIsMap && secondIsMap {
 				sh.AmbiguousSignatureWarn("get", sprigSignGet, sproutSignGet)
 			}
@@ -159,10 +159,9 @@ func (sh *SprigHandler) sprigSet(mr *maps.MapsRegistry) func(args ...any) (map[s
 			dict := args[2].(map[string]any)
 			return mr.Set(key, value, dict)
 		default:
-			// Both ends are maps, or neither is: the signature cannot be told
-			// apart, keep the Sprig behavior for backward compatibility. Only
-			// warn when the call is truly ambiguous, otherwise it is an
-			// argument error.
+			// Both ends are maps, or neither is: keep the Sprig behavior. Only
+			// the former is a signature ambiguity, the latter is an argument
+			// error the registry reports on its own.
 			if firstIsMap && lastIsMap {
 				sh.AmbiguousSignatureWarn("set", sprigSignSet, sproutSignSet)
 			}
@@ -212,9 +211,9 @@ func (sh *SprigHandler) sprigUnset(mr *maps.MapsRegistry) func(args ...any) (map
 			dict := args[1].(map[string]any)
 			return mr.Unset(key, dict)
 		default:
-			// Both are maps, or neither is: the signature cannot be told apart,
-			// keep the Sprig behavior for backward compatibility. Only warn when
-			// the call is truly ambiguous, otherwise it is an argument error.
+			// Both are maps, or neither is: keep the Sprig behavior. Only the
+			// former is a signature ambiguity, the latter is an argument error
+			// the registry reports on its own.
 			if firstIsMap && secondIsMap {
 				sh.AmbiguousSignatureWarn("unset", sprigSignUnset, sproutSignUnset)
 			}
@@ -263,9 +262,9 @@ func (sh *SprigHandler) sprigHasKey(mr *maps.MapsRegistry) func(args ...any) (bo
 			dict := args[1].(map[string]any)
 			return mr.HasKey(key, dict)
 		default:
-			// Both are maps, or neither is: the signature cannot be told apart,
-			// keep the Sprig behavior for backward compatibility. Only warn when
-			// the call is truly ambiguous, otherwise it is an argument error.
+			// Both are maps, or neither is: keep the Sprig behavior. Only the
+			// former is a signature ambiguity, the latter is an argument error
+			// the registry reports on its own.
 			if firstIsMap && secondIsMap {
 				sh.AmbiguousSignatureWarn("hasKey", sprigSignHasKey, sproutSignHasKey)
 			}
@@ -308,10 +307,9 @@ func (sh *SprigHandler) sprigPick(mr *maps.MapsRegistry) func(args ...any) (map[
 			// Already in correct order
 			return mr.Pick(args...)
 		default:
-			// Both ends are maps, or neither is: the signature cannot be told
-			// apart, keep the Sprig behavior for backward compatibility. Only
-			// warn when the call is truly ambiguous, otherwise it is an
-			// argument error.
+			// Both ends are maps, or neither is: keep the Sprig behavior. Only
+			// the former is a signature ambiguity, the latter is an argument
+			// error the registry reports on its own.
 			if firstIsMap && lastIsMap {
 				sh.AmbiguousSignatureWarn("pick", sprigSignPick, sproutSignPick)
 			}
@@ -351,10 +349,9 @@ func (sh *SprigHandler) sprigOmit(mr *maps.MapsRegistry) func(args ...any) (map[
 			// Already in correct order
 			return mr.Omit(args...)
 		default:
-			// Both ends are maps, or neither is: the signature cannot be told
-			// apart, keep the Sprig behavior for backward compatibility. Only
-			// warn when the call is truly ambiguous, otherwise it is an
-			// argument error.
+			// Both ends are maps, or neither is: keep the Sprig behavior. Only
+			// the former is a signature ambiguity, the latter is an argument
+			// error the registry reports on its own.
 			if firstIsMap && lastIsMap {
 				sh.AmbiguousSignatureWarn("omit", sprigSignOmit, sproutSignOmit)
 			}
@@ -422,14 +419,13 @@ func (sh *SprigHandler) sprigAppend(sr *slices.SlicesRegistry) func(args ...any)
 		case !firstIsList && secondIsList:
 			// New Sprout signature: append(value, list)
 			return sr.Append(first, second)
-		case firstIsList && secondIsList:
-			// Both are lists, the signature cannot be told apart: keep the Sprig
-			// behavior for backward compatibility and say so.
-			sh.AmbiguousSignatureWarn("append", sprigSignAppend, sproutSignAppend)
-			return sr.Append(second, first)
 		default:
-			// Neither is a list: this is an argument error, not a signature one,
-			// let the registry report it.
+			// Both are lists, or neither is: keep the Sprig behavior. Only the
+			// former is a signature ambiguity, the latter is an argument error
+			// the registry reports on its own.
+			if firstIsList && secondIsList {
+				sh.AmbiguousSignatureWarn("append", sprigSignAppend, sproutSignAppend)
+			}
 			return sr.Append(second, first)
 		}
 	}
@@ -458,14 +454,13 @@ func (sh *SprigHandler) sprigPrepend(sr *slices.SlicesRegistry) func(args ...any
 		case !firstIsList && secondIsList:
 			// New Sprout signature: prepend(value, list)
 			return sr.Prepend(first, second)
-		case firstIsList && secondIsList:
-			// Both are lists, the signature cannot be told apart: keep the Sprig
-			// behavior for backward compatibility and say so.
-			sh.AmbiguousSignatureWarn("prepend", sprigSignPrepend, sproutSignPrepend)
-			return sr.Prepend(second, first)
 		default:
-			// Neither is a list: this is an argument error, not a signature one,
-			// let the registry report it.
+			// Both are lists, or neither is: keep the Sprig behavior. Only the
+			// former is a signature ambiguity, the latter is an argument error
+			// the registry reports on its own.
+			if firstIsList && secondIsList {
+				sh.AmbiguousSignatureWarn("prepend", sprigSignPrepend, sproutSignPrepend)
+			}
 			return sr.Prepend(second, first)
 		}
 	}
@@ -500,16 +495,13 @@ func (sh *SprigHandler) sprigSlice(sr *slices.SlicesRegistry) func(args ...any) 
 			// New Sprout signature: slice(indices..., list)
 			// Already in correct order
 			return sr.Slice(args...)
-		case firstIsList && lastIsList:
-			// Both ends are lists, the signature cannot be told apart: keep the
-			// Sprig behavior for backward compatibility and say so.
-			sh.AmbiguousSignatureWarn("slice", sprigSignSlice, sproutSignSlice)
-			list := args[0]
-			indices := args[1:]
-			return sr.Slice(append(indices, list)...)
 		default:
-			// No list at either end: this is an argument error, not a signature
-			// one, let the registry report it.
+			// Both ends are lists, or neither is: keep the Sprig behavior. Only
+			// the former is a signature ambiguity, the latter is an argument
+			// error the registry reports on its own.
+			if firstIsList && lastIsList {
+				sh.AmbiguousSignatureWarn("slice", sprigSignSlice, sproutSignSlice)
+			}
 			list := args[0]
 			indices := args[1:]
 			return sr.Slice(append(indices, list)...)
@@ -542,16 +534,13 @@ func (sh *SprigHandler) sprigWithout(sr *slices.SlicesRegistry) func(args ...any
 			// New Sprout signature: without(omit..., list)
 			// Already in correct order
 			return sr.Without(args...)
-		case firstIsList && lastIsList:
-			// Both ends are lists, the signature cannot be told apart: keep the
-			// Sprig behavior for backward compatibility and say so.
-			sh.AmbiguousSignatureWarn("without", sprigSignWithout, sproutSignWithout)
-			list := args[0]
-			omit := args[1:]
-			return sr.Without(append(omit, list)...)
 		default:
-			// No list at either end: this is an argument error, not a signature
-			// one, let the registry report it.
+			// Both ends are lists, or neither is: keep the Sprig behavior. Only
+			// the former is a signature ambiguity, the latter is an argument
+			// error the registry reports on its own.
+			if firstIsList && lastIsList {
+				sh.AmbiguousSignatureWarn("without", sprigSignWithout, sproutSignWithout)
+			}
 			list := args[0]
 			omit := args[1:]
 			return sr.Without(append(omit, list)...)


### PR DESCRIPTION
## Description

Issue #180 reports that `{{ $list | append $value }}` "does not work" inside a `range`. Investigating it surfaced three real problems in how Sprout guides a migration, all of which made that mistake easy to fall into.

This PR fixes the guidance. The same calls return the same results, only the messages, the errors and the documentation change.

## Changes

- The migration warning never showed the assignment
- Ambiguous calls were told to migrate to the signature they already use
- Pure Sprout failed without saying what to fix
- Documentation reproduced the trap

## Fixes #180 

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.